### PR TITLE
[FEAT] 메인 화면 리사이클러뷰 구현, 레이아웃 변경 로직 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,24 +4,31 @@
     <option name="filePathToZoomLevelMap">
       <map>
         <entry key="app/src/main/res/drawable/background_line.xml" value="0.1135" />
-        <entry key="app/src/main/res/drawable/bg_main_title_tv.xml" value="0.1" />
+        <entry key="app/src/main/res/drawable/background_spinner.xml" value="0.1" />
         <entry key="app/src/main/res/drawable/ic_cart.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/ic_check.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/ic_checkbox_checked.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/ic_checkbox_empty.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/ic_circle_cart.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/ic_circle_checkd.xml" value="0.1135" />
-        <entry key="app/src/main/res/layout/activity_main.xml" value="0.1" />
-        <entry key="app/src/main/res/layout/fragment_best.xml" value="0.2" />
-        <entry key="app/src/main/res/layout/fragment_home.xml" value="0.16302083333333334" />
-        <entry key="app/src/main/res/layout/fragment_main_cook.xml" value="0.25" />
-        <entry key="app/src/main/res/layout/fragment_side.xml" value="0.16302083333333334" />
-        <entry key="app/src/main/res/layout/fragment_soup.xml" value="0.33" />
+        <entry key="app/src/main/res/drawable/ic_downbutton.xml" value="0.1" />
+        <entry key="app/src/main/res/drawable/ic_grid.xml" value="0.1" />
+        <entry key="app/src/main/res/drawable/item_option.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/activity_main.xml" value="0.24478178368121442" />
+        <entry key="app/src/main/res/layout/fragment_home.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_main_cook.xml" value="0.1" />
         <entry key="app/src/main/res/layout/item_banchan.xml" value="0.5686782836914064" />
-        <entry key="app/src/main/res/layout/item_best_list.xml" value="0.33" />
-        <entry key="app/src/main/res/layout/item_home_header.xml" value="0.5" />
-        <entry key="app/src/main/res/layout/item_menu.xml" value="0.33" />
-        <entry key="app/src/main/res/layout/layout_home_main_title.xml" value="0.33" />
+        <entry key="app/src/main/res/layout/item_home_header.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/item_main_filter.xml" value="0.6353363921676858" />
+        <entry key="app/src/main/res/layout/item_main_header.xml" value="0.39651794433593757" />
+        <entry key="app/src/main/res/layout/item_medium.xml" value="0.2939702794171762" />
+        <entry key="app/src/main/res/layout/item_menu.xml" value="0.2964472946611423" />
+        <entry key="app/src/main/res/layout/item_menu_filter.xml" value="0.551953125" />
+        <entry key="app/src/main/res/layout/item_menu_land.xml" value="0.25" />
+        <entry key="app/src/main/res/layout/item_menu_medium.xml" value="0.2964472946611423" />
+        <entry key="app/src/main/res/layout/item_option.xml" value="0.1272644927536232" />
+        <entry key="app/src/main/res/layout/menu_filter.xml" value="0.10009057971014493" />
+        <entry key="app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml" value="0.1" />
       </map>
     </option>
   </component>
@@ -30,5 +37,12 @@
   </component>
   <component name="ProjectType">
     <option name="id" value="Android" />
+  </component>
+  <component name="VisualizationToolProject">
+    <option name="state">
+      <ProjectState>
+        <option name="scale" value="0.2964472946611423" />
+      </ProjectState>
+    </option>
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.banchan"
-        minSdk 21
+        minSdk 23
         targetSdk 32
         versionCode 1
         versionName "1.0"
@@ -54,6 +54,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation "androidx.fragment:fragment-ktx:1.5.0"
+    implementation "androidx.recyclerview:recyclerview:1.3.0-beta01"
 
     // glide
     implementation "com.github.bumptech.glide:glide:$glide_version"

--- a/app/src/main/java/com/example/banchan/MockData.kt
+++ b/app/src/main/java/com/example/banchan/MockData.kt
@@ -1,10 +1,10 @@
 package com.example.banchan
 
+import com.example.banchan.domain.model.BestListItem
 import com.example.banchan.domain.model.BestModel
 import com.example.banchan.domain.model.ItemModel
-import com.example.banchan.domain.model.BestListItem
 
-val fakeItem = listOf(
+var fakeData: MutableList<ItemModel> = mutableListOf(
     ItemModel(
         detailHash = "HBDEF",
         image = "http://public.codesquad.kr/jk/storeapp/data/main/1155_ZIP_P_0081_T.jpg",
@@ -13,7 +13,8 @@ val fakeItem = listOf(
         originPrice = "15,800",
         discountPrice = "12,640원",
         discountPercent = "20%"
-    ), ItemModel(
+    ),
+    ItemModel(
         detailHash = "HBDEF",
         image = "http://public.codesquad.kr/jk/storeapp/data/main/1155_ZIP_P_0081_T.jpg",
         title = "오리 주물럭_반조리",
@@ -22,7 +23,8 @@ val fakeItem = listOf(
         discountPrice = "12,640원",
         discountPercent = "20%",
         isCartAdded = true
-    ), ItemModel(
+    ),
+    ItemModel(
         detailHash = "HBDEF",
         image = "http://public.codesquad.kr/jk/storeapp/data/main/1155_ZIP_P_0081_T.jpg",
         title = "오리 주물럭_반조리",
@@ -30,16 +32,38 @@ val fakeItem = listOf(
         originPrice = "15,800",
         discountPrice = null,
         discountPercent = null
-    ), ItemModel(
+    ),
+    ItemModel(
         detailHash = "HBDEF",
         image = "http://public.codesquad.kr/jk/storeapp/data/main/1155_ZIP_P_0081_T.jpg",
         title = "오리 주물럭_반조리",
         description = "감칠맛 나는 매콤한 양념",
         originPrice = "15,800",
-        discountPrice = "12,640원",
-        discountPercent = "20%",
-        isCartAdded = true
-    ), ItemModel(
+        discountPrice = null,
+        discountPercent = null
+    ),
+    ItemModel(
+        detailHash = "HBDEF",
+        image = "http://public.codesquad.kr/jk/storeapp/data/main/1155_ZIP_P_0081_T.jpg",
+        title = "오리 주물럭_반조리",
+        description = "감칠맛 나는 매콤한 양념",
+        originPrice = "15,800",
+        discountPrice = null,
+        discountPercent = null
+    ),
+    ItemModel(
+        detailHash = "HBDEF",
+        image = "http://public.codesquad.kr/jk/storeapp/data/main/1155_ZIP_P_0081_T.jpg",
+        title = "오리 주물럭_반조리",
+        description = "감칠맛 나는 매콤한 양념",
+        originPrice = "15,800",
+        discountPrice = null,
+        discountPercent = null
+    )
+)
+
+val fakeItem = listOf(
+    ItemModel(
         detailHash = "HBDEF",
         image = "http://public.codesquad.kr/jk/storeapp/data/main/1155_ZIP_P_0081_T.jpg",
         title = "오리 주물럭_반조리",
@@ -51,7 +75,7 @@ val fakeItem = listOf(
 )
 
 val fakeBestItem: List<BestListItem> = listOf(
-    BestListItem.BestHeader(),
+    BestListItem.BestHeader,
     BestListItem.BestContent(
         BestModel(
             title = "풍성한 고기반찬",

--- a/app/src/main/java/com/example/banchan/data/response/main/MainResponse.kt
+++ b/app/src/main/java/com/example/banchan/data/response/main/MainResponse.kt
@@ -1,10 +1,16 @@
 package com.example.banchan.data.response.main
 
 import com.example.banchan.data.response.best.Item
+import com.example.banchan.domain.model.BestModel
+import com.example.banchan.domain.model.ItemModel
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class MainResponse(
     val body: List<Item>,
     val statusCode: Int
-)
+) {
+    fun toMainModel(): List<ItemModel> {
+        return body.map { it.toItemModel() }
+    }
+}

--- a/app/src/main/java/com/example/banchan/domain/model/ItemModel.kt
+++ b/app/src/main/java/com/example/banchan/domain/model/ItemModel.kt
@@ -1,5 +1,7 @@
 package com.example.banchan.domain.model
 
+import com.example.banchan.presentation.home.maincook.adapter.Type
+
 data class ItemModel(
     val description: String,
     val detailHash: String,
@@ -10,3 +12,9 @@ data class ItemModel(
     val title: String,
     val isCartAdded: Boolean = false
 )
+
+sealed class ItemListModel {
+    data class Header(val currentType: Type) : ItemListModel()
+    data class SmallItem(val item: ItemModel) : ItemListModel()
+    data class LargeItem(val item: ItemModel) : ItemListModel()
+}

--- a/app/src/main/java/com/example/banchan/domain/usecase/GetMainDishesUseCase.kt
+++ b/app/src/main/java/com/example/banchan/domain/usecase/GetMainDishesUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.banchan.domain.usecase
+
+import com.example.banchan.data.repository.BanChanRepository
+import com.example.banchan.domain.model.ItemModel
+import javax.inject.Inject
+
+class GetMainDishesUseCase @Inject constructor(
+    private val repository: BanChanRepository
+) {
+    suspend operator fun invoke(): List<ItemModel> =
+        repository.getMain().getOrThrow().toMainModel()
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/best/BestListAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/best/BestListAdapter.kt
@@ -84,6 +84,6 @@ class BestContentViewHolder(
 
         val menuAdapter = MenuAdapter()
         binding.rvBestList.adapter = menuAdapter
-        menuAdapter.submitList(bestModel.bestItem.items) {}
+        menuAdapter.submitList(bestModel.bestItem.items)
     }
 }

--- a/app/src/main/java/com/example/banchan/presentation/adapter/best/BestListAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/best/BestListAdapter.kt
@@ -7,9 +7,9 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.banchan.R
-import com.example.banchan.domain.model.BestListItem
 import com.example.banchan.databinding.ItemBestListBinding
 import com.example.banchan.databinding.ItemHomeHeaderBinding
+import com.example.banchan.domain.model.BestListItem
 import com.example.banchan.presentation.adapter.menu.MenuAdapter
 
 class BestListAdapter :
@@ -84,6 +84,6 @@ class BestContentViewHolder(
 
         val menuAdapter = MenuAdapter()
         binding.rvBestList.adapter = menuAdapter
-        menuAdapter.submitList(bestModel.bestItem.items)
+        menuAdapter.submitList(bestModel.bestItem.items) {}
     }
 }

--- a/app/src/main/java/com/example/banchan/presentation/custom/MenuSpinner.kt
+++ b/app/src/main/java/com/example/banchan/presentation/custom/MenuSpinner.kt
@@ -1,11 +1,11 @@
-package com.example.banchan.ui
+package com.example.banchan.presentation.custom
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import androidx.appcompat.widget.AppCompatSpinner
 import com.example.banchan.R
@@ -16,43 +16,12 @@ class MenuSpinner(
     attributeSet: AttributeSet
 ) : AppCompatSpinner(context, attributeSet) {
 
-    private lateinit var onFocusedListener: (Boolean) -> Unit
-    private var isOpened = false
-
-    fun setOnFocusedListener(onFocusedListener: (Boolean) -> Unit) {
-        this.onFocusedListener = onFocusedListener
-    }
-
     override fun performClick(): Boolean {
-        if (::onFocusedListener.isInitialized) {
-            isOpened = true
-            onFocusedListener(isOpened)
-        }
         return super.performClick()
     }
 
     override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
-        if (::onFocusedListener.isInitialized && isOpened && hasWindowFocus) {
-            isOpened = false
-            onFocusedListener(false)
-        }
         super.onWindowFocusChanged(hasWindowFocus)
-    }
-
-    fun setOnItemClickListener(onItemClickListener: (Long) -> Unit) {
-        this.onItemSelectedListener = object :
-            OnItemSelectedListener {
-            override fun onItemSelected(
-                adapter: AdapterView<*>?,
-                view: View?,
-                position: Int,
-                id: Long
-            ) {
-                onItemClickListener(id)
-            }
-
-            override fun onNothingSelected(p0: AdapterView<*>?) {}
-        }
     }
 }
 
@@ -66,13 +35,15 @@ class OptionAdapter(
     override fun getItem(position: Int) = optionValue[position]
     override fun getItemId(position: Int) = position.toLong()
 
+    @SuppressLint("ViewHolder")
     override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
         val binding = ItemMenuFilterBinding.inflate(layoutInflater, parent, false)
-        binding.tvIssueType.text = "안녕하세요"
+        binding.tvIssueType.text = "구현중"
         return binding.root
     }
 
     override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View =
         convertView ?: ItemMenuFilterBinding.inflate(layoutInflater, parent, false).apply {
+
         }.root
 }

--- a/app/src/main/java/com/example/banchan/presentation/customview/MenuSpinner.kt
+++ b/app/src/main/java/com/example/banchan/presentation/customview/MenuSpinner.kt
@@ -1,0 +1,78 @@
+package com.example.banchan.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import androidx.appcompat.widget.AppCompatSpinner
+import com.example.banchan.R
+import com.example.banchan.databinding.ItemMenuFilterBinding
+
+class MenuSpinner(
+    context: Context,
+    attributeSet: AttributeSet
+) : AppCompatSpinner(context, attributeSet) {
+
+    private lateinit var onFocusedListener: (Boolean) -> Unit
+    private var isOpened = false
+
+    fun setOnFocusedListener(onFocusedListener: (Boolean) -> Unit) {
+        this.onFocusedListener = onFocusedListener
+    }
+
+    override fun performClick(): Boolean {
+        if (::onFocusedListener.isInitialized) {
+            isOpened = true
+            onFocusedListener(isOpened)
+        }
+        return super.performClick()
+    }
+
+    override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
+        if (::onFocusedListener.isInitialized && isOpened && hasWindowFocus) {
+            isOpened = false
+            onFocusedListener(false)
+        }
+        super.onWindowFocusChanged(hasWindowFocus)
+    }
+
+    fun setOnItemClickListener(onItemClickListener: (Long) -> Unit) {
+        this.onItemSelectedListener = object :
+            OnItemSelectedListener {
+            override fun onItemSelected(
+                adapter: AdapterView<*>?,
+                view: View?,
+                position: Int,
+                id: Long
+            ) {
+                onItemClickListener(id)
+            }
+
+            override fun onNothingSelected(p0: AdapterView<*>?) {}
+        }
+    }
+}
+
+class OptionAdapter(
+    context: Context,
+    private val optionValue: List<String>
+) : ArrayAdapter<String>(context, R.layout.menu_filter) {
+    private val layoutInflater = LayoutInflater.from(context)
+
+    override fun getCount() = optionValue.size
+    override fun getItem(position: Int) = optionValue[position]
+    override fun getItemId(position: Int) = position.toLong()
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val binding = ItemMenuFilterBinding.inflate(layoutInflater, parent, false)
+        binding.tvIssueType.text = "안녕하세요"
+        return binding.root
+    }
+
+    override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View =
+        convertView ?: ItemMenuFilterBinding.inflate(layoutInflater, parent, false).apply {
+        }.root
+}

--- a/app/src/main/java/com/example/banchan/presentation/home/best/BestFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/best/BestFragment.kt
@@ -6,8 +6,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentBestBinding
 import com.example.banchan.fakeBestItem
+import com.example.banchan.presentation.adapter.best.BestListAdapter
 import com.example.banchan.presentation.base.BaseFragment
-import com.example.banchan.presentation.home.best.adapter.BestListAdapter
 import com.example.banchan.util.dimen.dpToPx
 
 class BestFragment : BaseFragment<FragmentBestBinding>(R.layout.fragment_best) {

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookFragment.kt
@@ -1,60 +1,65 @@
 package com.example.banchan.presentation.home.maincook
 
-import android.os.Bundle
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.banchan.R
+import com.example.banchan.data.response.ItemListModel
+import com.example.banchan.databinding.FragmentMainCookBinding
+import com.example.banchan.fakeData
+import com.example.banchan.presentation.base.BaseFragment
+import com.example.banchan.presentation.home.maincook.adapter.Filter
+import com.example.banchan.presentation.home.maincook.adapter.MainAdapter
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
+class MainCookFragment : BaseFragment<FragmentMainCookBinding>(R.layout.fragment_main_cook) {
+    private val viewModel by viewModels<MainCookViewModel>()
 
-/**
- * A simple [Fragment] subclass.
- * Use the [MainCookFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
-class MainCookFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
+    private val mainAdapter by lazy {
+        MainAdapter {
+            changeListMode(it)
+            viewModel.changeMode(it)
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_main_cook, container, false)
-    }
+    override fun initViews() {
+        binding.rvMain.apply {
+            adapter = mainAdapter
+            itemAnimator = null
+        }
+        changeListMode(Filter.Grid)
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment MainCookFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            MainCookFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.fake.collect {
+                    mainAdapter.submitList(it)
                 }
             }
+        }
+    }
+
+    override fun observe() {
+    }
+
+    private fun changeListMode(type: Filter) {
+        if (type == Filter.Linear) {
+            binding.rvMain.layoutManager = LinearLayoutManager(requireActivity())
+        } else {
+            binding.rvMain.layoutManager = GridLayoutManager(requireActivity(), 2)
+            (binding.rvMain.layoutManager as GridLayoutManager).spanSizeLookup =
+                object : GridLayoutManager.SpanSizeLookup() {
+                    override fun getSpanSize(position: Int): Int {
+                        return when (mainAdapter.getItemViewType(position)) {
+                            MainAdapter.HEADER_VIEW_TYPE -> 2
+                            else -> 1
+                        }
+                    }
+                }
+        }
     }
 }

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookFragment.kt
@@ -7,23 +7,23 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.banchan.R
-import com.example.banchan.data.response.ItemListModel
 import com.example.banchan.databinding.FragmentMainCookBinding
-import com.example.banchan.fakeData
+import com.example.banchan.domain.model.ItemListModel
 import com.example.banchan.presentation.base.BaseFragment
-import com.example.banchan.presentation.home.maincook.adapter.Filter
 import com.example.banchan.presentation.home.maincook.adapter.MainAdapter
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.collectLatest
+import com.example.banchan.presentation.home.maincook.adapter.SpacingItemDecorator
+import com.example.banchan.presentation.home.maincook.adapter.Type
+import com.example.banchan.util.dimen.dpToPx
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class MainCookFragment : BaseFragment<FragmentMainCookBinding>(R.layout.fragment_main_cook) {
     private val viewModel by viewModels<MainCookViewModel>()
 
     private val mainAdapter by lazy {
         MainAdapter {
-            changeListMode(it)
-            viewModel.changeMode(it)
+            viewModel.changeType(it)
         }
     }
 
@@ -31,13 +31,16 @@ class MainCookFragment : BaseFragment<FragmentMainCookBinding>(R.layout.fragment
         binding.rvMain.apply {
             adapter = mainAdapter
             itemAnimator = null
+            addItemDecoration(SpacingItemDecorator(dpToPx(requireActivity(), 4)))
         }
-        changeListMode(Filter.Grid)
+        changeListType(Type.Grid)
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.fake.collect {
-                    mainAdapter.submitList(it)
+                    mainAdapter.submitList(it) {
+                        changeListType((it[0] as ItemListModel.Header).currentType)
+                    }
                 }
             }
         }
@@ -46,20 +49,23 @@ class MainCookFragment : BaseFragment<FragmentMainCookBinding>(R.layout.fragment
     override fun observe() {
     }
 
-    private fun changeListMode(type: Filter) {
-        if (type == Filter.Linear) {
-            binding.rvMain.layoutManager = LinearLayoutManager(requireActivity())
-        } else {
-            binding.rvMain.layoutManager = GridLayoutManager(requireActivity(), 2)
-            (binding.rvMain.layoutManager as GridLayoutManager).spanSizeLookup =
-                object : GridLayoutManager.SpanSizeLookup() {
-                    override fun getSpanSize(position: Int): Int {
-                        return when (mainAdapter.getItemViewType(position)) {
-                            MainAdapter.HEADER_VIEW_TYPE -> 2
-                            else -> 1
+    private fun changeListType(type: Type) {
+        when (type) {
+            Type.Linear -> {
+                binding.rvMain.layoutManager = LinearLayoutManager(requireActivity())
+            }
+            Type.Grid -> {
+                binding.rvMain.layoutManager = GridLayoutManager(requireActivity(), 2)
+                (binding.rvMain.layoutManager as GridLayoutManager).spanSizeLookup =
+                    object : GridLayoutManager.SpanSizeLookup() {
+                        override fun getSpanSize(position: Int): Int {
+                            return when (mainAdapter.getItemViewType(position)) {
+                                MainAdapter.HEADER_VIEW_TYPE -> 2
+                                else -> 1
+                            }
                         }
                     }
-                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookFragment.kt
@@ -37,7 +37,7 @@ class MainCookFragment : BaseFragment<FragmentMainCookBinding>(R.layout.fragment
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.fake.collect {
+                viewModel.menus.collect {
                     mainAdapter.submitList(it) {
                         changeListType((it[0] as ItemListModel.Header).currentType)
                     }

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookViewModel.kt
@@ -15,10 +15,10 @@ import javax.inject.Inject
 class MainCookViewModel @Inject constructor(
     private val getMainDishesUseCase: GetMainDishesUseCase
 ) : ViewModel() {
-    private val filter = MutableStateFlow(Type.Grid)
-    val fake = filter.map { filter ->
-        listOf(ItemListModel.Header(filter)) + getMainDishesUseCase().map {
-            if (filter == Type.Grid) {
+    private val type = MutableStateFlow(Type.Grid)
+    val menus = type.map { type ->
+        listOf(ItemListModel.Header(type)) + getMainDishesUseCase().map {
+            if (type == Type.Grid) {
                 ItemListModel.SmallItem(it)
             } else {
                 ItemListModel.LargeItem(it)
@@ -28,7 +28,7 @@ class MainCookViewModel @Inject constructor(
 
     fun changeType(type: Type) {
         viewModelScope.launch {
-            filter.emit(type)
+            this@MainCookViewModel.type.emit(type)
         }
     }
 }

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookViewModel.kt
@@ -1,0 +1,29 @@
+package com.example.banchan.presentation.home.maincook
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.banchan.data.response.ItemListModel
+import com.example.banchan.fakeData
+import com.example.banchan.presentation.home.maincook.adapter.Filter
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+class MainCookViewModel : ViewModel() {
+    val filter = MutableStateFlow(Filter.Grid)
+    val fake = filter.map { filter ->
+        listOf(ItemListModel.Header) + fakeData.map {
+            if (filter == Filter.Grid) {
+                ItemListModel.SmallItem(it)
+            } else {
+                ItemListModel.LargeItem(it)
+            }
+        }
+    }
+
+    fun changeMode(type: Filter) {
+        viewModelScope.launch {
+            filter.emit(type)
+        }
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookViewModel.kt
@@ -2,18 +2,23 @@ package com.example.banchan.presentation.home.maincook
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.banchan.data.response.ItemListModel
-import com.example.banchan.fakeData
-import com.example.banchan.presentation.home.maincook.adapter.Filter
+import com.example.banchan.domain.model.ItemListModel
+import com.example.banchan.domain.usecase.GetMainDishesUseCase
+import com.example.banchan.presentation.home.maincook.adapter.Type
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class MainCookViewModel : ViewModel() {
-    val filter = MutableStateFlow(Filter.Grid)
+@HiltViewModel
+class MainCookViewModel @Inject constructor(
+    private val getMainDishesUseCase: GetMainDishesUseCase
+) : ViewModel() {
+    private val filter = MutableStateFlow(Type.Grid)
     val fake = filter.map { filter ->
-        listOf(ItemListModel.Header) + fakeData.map {
-            if (filter == Filter.Grid) {
+        listOf(ItemListModel.Header(filter)) + getMainDishesUseCase().map {
+            if (filter == Type.Grid) {
                 ItemListModel.SmallItem(it)
             } else {
                 ItemListModel.LargeItem(it)
@@ -21,7 +26,7 @@ class MainCookViewModel : ViewModel() {
         }
     }
 
-    fun changeMode(type: Filter) {
+    fun changeType(type: Type) {
         viewModelScope.launch {
             filter.emit(type)
         }

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/adapter/LargeMenuViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/adapter/LargeMenuViewHolder.kt
@@ -1,0 +1,26 @@
+package com.example.banchan.presentation.home.maincook.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.databinding.ItemMenuLargeBinding
+import com.example.banchan.domain.model.ItemModel
+
+class LargeMenuViewHolder(private val binding: ItemMenuLargeBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+    fun bind(item: ItemModel, onClick: (String) -> Unit) {
+        binding.item = item
+        binding.ivCart.setOnClickListener { onClick(item.detailHash) }
+        binding.executePendingBindings()
+    }
+
+    companion object {
+        fun create(parent: ViewGroup) = LargeMenuViewHolder(
+            ItemMenuLargeBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/adapter/MainAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/adapter/MainAdapter.kt
@@ -1,0 +1,79 @@
+package com.example.banchan.presentation.home.maincook.adapter
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.domain.model.ItemListModel
+
+enum class Type {
+    Grid, Linear
+}
+
+class MainAdapter(private val onFilterChange: (Type) -> Unit) :
+    ListAdapter<ItemListModel, RecyclerView.ViewHolder>(DiffCallback()) {
+    override fun getItemViewType(position: Int): Int {
+        return when (getItem(position)) {
+            is ItemListModel.Header -> HEADER_VIEW_TYPE
+            is ItemListModel.LargeItem -> LARGE_ITEM_VIEW_TYPE
+            is ItemListModel.SmallItem -> MEDIUM_ITEM_VIEW_TYPE
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            HEADER_VIEW_TYPE -> {
+                MainFilterViewHolder.create(parent)
+            }
+            LARGE_ITEM_VIEW_TYPE -> {
+                LargeMenuViewHolder.create(parent)
+            }
+            MEDIUM_ITEM_VIEW_TYPE -> {
+                MediumMenuViewHolder.create(parent)
+            }
+            else -> {
+                throw UnsupportedOperationException("Unknown view")
+            }
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (val item = getItem(position)) {
+            is ItemListModel.Header ->
+                (holder as MainFilterViewHolder).bind(item.currentType, onFilterChange)
+            is ItemListModel.LargeItem -> {
+                (holder as LargeMenuViewHolder).bind(item.item) {}
+            }
+            is ItemListModel.SmallItem -> {
+                (holder as MediumMenuViewHolder).bind(item.item) {}
+            }
+        }
+    }
+
+    companion object {
+        const val HEADER_VIEW_TYPE = 0
+        const val LARGE_ITEM_VIEW_TYPE = 1
+        const val MEDIUM_ITEM_VIEW_TYPE = 2
+
+        class DiffCallback : DiffUtil.ItemCallback<ItemListModel>() {
+            override fun areItemsTheSame(
+                oldItem: ItemListModel,
+                newItem: ItemListModel
+            ): Boolean {
+                return (oldItem is ItemListModel.Header && newItem is ItemListModel.Header &&
+                        oldItem.currentType == newItem.currentType) ||
+                        (oldItem is ItemListModel.SmallItem && newItem is ItemListModel.SmallItem &&
+                                oldItem.item.detailHash == newItem.item.detailHash) ||
+                        (oldItem is ItemListModel.LargeItem && newItem is ItemListModel.LargeItem &&
+                                oldItem.item.detailHash == newItem.item.detailHash)
+            }
+
+            override fun areContentsTheSame(
+                oldItem: ItemListModel,
+                newItem: ItemListModel
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/adapter/MainFilterViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/adapter/MainFilterViewHolder.kt
@@ -5,7 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.example.banchan.R
 import com.example.banchan.databinding.MenuFilterBinding
-import com.example.banchan.ui.OptionAdapter
+import com.example.banchan.presentation.custom.OptionAdapter
 
 class MainFilterViewHolder(private val binding: MenuFilterBinding) :
     RecyclerView.ViewHolder(binding.root) {

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/adapter/MainFilterViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/adapter/MainFilterViewHolder.kt
@@ -1,0 +1,48 @@
+package com.example.banchan.presentation.home.maincook.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.R
+import com.example.banchan.databinding.MenuFilterBinding
+import com.example.banchan.ui.OptionAdapter
+
+class MainFilterViewHolder(private val binding: MenuFilterBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+    fun bind(currentFilter: Type, onClick: (Type) -> Unit) {
+        val grayColor = binding.root.resources.getColor(
+            R.color.greyscale_default, null
+        )
+        val blackColor = binding.root.resources.getColor(
+            R.color.black, null
+        )
+        binding.spinnerMain.adapter = OptionAdapter(binding.root.context, listOf("안녕", "안녕"))
+        binding.ivList.setOnClickListener {
+            onClick(Type.Linear)
+        }
+        binding.ivGrid.setOnClickListener {
+            onClick(Type.Grid)
+        }
+
+        when (currentFilter) {
+            Type.Grid -> {
+                binding.ivGrid.setColorFilter(blackColor)
+                binding.ivList.setColorFilter(grayColor)
+            }
+            Type.Linear -> {
+                binding.ivGrid.setColorFilter(grayColor)
+                binding.ivList.setColorFilter(blackColor)
+            }
+        }
+    }
+
+    companion object {
+        fun create(parent: ViewGroup) = MainFilterViewHolder(
+            MenuFilterBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/adapter/MediumMenuViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/adapter/MediumMenuViewHolder.kt
@@ -1,0 +1,26 @@
+package com.example.banchan.presentation.home.maincook.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.databinding.ItemMenuMediumBinding
+import com.example.banchan.domain.model.ItemModel
+
+class MediumMenuViewHolder(private val binding: ItemMenuMediumBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+    fun bind(item: ItemModel, onClick: (String) -> Unit) {
+        binding.item = item
+        binding.ivCart.setOnClickListener { onClick(item.detailHash) }
+        binding.executePendingBindings()
+    }
+
+    companion object {
+        fun create(parent: ViewGroup) = MediumMenuViewHolder(
+            ItemMenuMediumBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/adapter/SpacingItemDecorator.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/adapter/SpacingItemDecorator.kt
@@ -1,0 +1,20 @@
+package com.example.banchan.presentation.home.maincook.adapter
+
+import android.graphics.Rect
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+class SpacingItemDecorator(private val padding: Int) : RecyclerView.ItemDecoration() {
+    override fun getItemOffsets(
+        outRect: Rect,
+        view: View,
+        parent: RecyclerView,
+        state: RecyclerView.State
+    ) {
+        super.getItemOffsets(outRect, view, parent, state)
+        outRect.top = padding
+        outRect.bottom = padding
+        outRect.left = padding
+        outRect.right = padding
+    }
+}

--- a/app/src/main/res/drawable/background_spinner.xml
+++ b/app/src/main/res/drawable/background_spinner.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white" />
+    <corners android:radius="14dp" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout_main_container"
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_main_cook.xml
+++ b/app/src/main/res/layout/fragment_main_cook.xml
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    tools:context=".presentation.home.maincook.MainCookFragment">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="main_cook"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <data>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.home.maincook.MainCookFragment">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_main"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="12dp"
+            tools:listitem="@layout/item_menu" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_menu_filter.xml
+++ b/app/src/main/res/layout/item_menu_filter.xml
@@ -9,7 +9,7 @@
     android:paddingVertical="8dp">
 
     <TextView
-        android:id="@+id/tv_issue_type"
+        android:id="@+id/tv_filter_type"
         style="@style/tv_normal_14.Black"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_menu_filter.xml
+++ b/app/src/main/res/layout/item_menu_filter.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@android:color/transparent"
+    android:paddingHorizontal="16dp"
+    android:paddingVertical="8dp">
+
+    <TextView
+        android:id="@+id/tv_issue_type"
+        style="@style/tv_normal_14.Black"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="기본 정렬순" />
+
+    <ImageView
+        android:id="@+id/img_check_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_check"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="@color/primary_accent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_menu_large.xml
+++ b/app/src/main/res/layout/item_menu_large.xml
@@ -13,7 +13,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
         <ImageView
@@ -40,10 +40,13 @@
             style="@style/tv_normal_14.Black"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginBottom="8dp"
             android:text="@{item.title}"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/iv_banchan"
+            app:layout_constraintBottom_toTopOf="@id/tv_content"
+            app:layout_constraintStart_toEndOf="@id/iv_banchan"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed"
             tools:text="오리주물럭" />
 
         <TextView
@@ -52,8 +55,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@{item.description}"
-            app:layout_constraintBottom_toTopOf="@id/tv_discount"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/tv_display_price"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
             app:layout_constraintTop_toBottomOf="@id/tv_title"
             tools:text="감칠맛 나는 양념" />
 
@@ -67,7 +70,7 @@
             android:visibility="@{item.discountPercent == null ? View.GONE : View.VISIBLE}"
             app:layout_constraintEnd_toStartOf="@id/tv_display_price"
             app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tv_content"
             app:layout_constraintTop_toTopOf="@id/tv_display_price"
             tools:text="20%" />
 
@@ -78,6 +81,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="7dp"
             android:text="@{item.discountPercent == null ? item.originPrice : item.discountPrice}"
+            app:layout_constraintBottom_toTopOf="@id/tv_origin_price"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/tv_discount"
             app:layout_constraintTop_toBottomOf="@id/tv_content"
@@ -92,7 +96,8 @@
             android:background="@drawable/background_line"
             android:text="@{item.originPrice}"
             android:visibility="@{item.discountPercent == null ? View.GONE : View.VISIBLE}"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tv_content"
             app:layout_constraintTop_toBottomOf="@id/tv_display_price"
             tools:text="1234원" />
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_menu_medium.xml
+++ b/app/src/main/res/layout/item_menu_medium.xml
@@ -13,14 +13,14 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
         <ImageView
             android:id="@+id/iv_banchan"
             imageUrl="@{item.image}"
-            android:layout_width="160dp"
-            android:layout_height="160dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:src="@tools:sample/avatars" />

--- a/app/src/main/res/layout/menu_filter.xml
+++ b/app/src/main/res/layout/menu_filter.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/iv_grid"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_grid"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/iv_list"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_linear"
+        app:layout_constraintStart_toEndOf="@id/iv_grid"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.example.banchan.ui.MenuSpinner
+        android:id="@+id/spinner_main"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/menu_filter.xml
+++ b/app/src/main/res/layout/menu_filter.xml
@@ -20,7 +20,7 @@
         app:layout_constraintStart_toEndOf="@id/iv_grid"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <com.example.banchan.ui.MenuSpinner
+    <com.example.banchan.presentation.custom.MenuSpinner
         android:id="@+id/spinner_main"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
메인 화면 리사이클러뷰 구현, 레이아웃 변경 로직 구현

## Main Changes
- 메인 화면 리사이클러뷰 구현
- 레이아웃 변경 로직 구현
`nestedscrollview`를 사용하는 대신 하나의 `recyclerview`로 구현하기 위해 다이나믹하게 레이아웃 매니저를 바꾸는 방식으로 구현해보았습니다.

스피너는 조금 구현해두었는데, 다음 pr로 분리해서 올리겠습니다!

<img src="https://user-images.githubusercontent.com/54823396/183946548-03108f7f-a536-40c6-bb9d-20acd1890190.gif" width="40%" /> <img src="https://user-images.githubusercontent.com/54823396/183945689-1c5b7cf2-0b66-46a0-8567-c3ad981c399a.gif" width="40%" />
