### PR TITLE
[FEAT] Home 화면의 기획전 탭 화면 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,6 +5,7 @@
       <map>
         <entry key="app/src/main/res/drawable/background_line.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/bg_main_title_tv.xml" value="0.1" />
+        <entry key="app/src/main/res/drawable/ic_baseline_error_24.xml" value="0.3495" />
         <entry key="app/src/main/res/drawable/ic_cart.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/ic_check.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/ic_checkbox_checked.xml" value="0.1135" />
@@ -19,7 +20,10 @@
         <entry key="app/src/main/res/layout/fragment_soup.xml" value="0.33" />
         <entry key="app/src/main/res/layout/item_banchan.xml" value="0.5686782836914064" />
         <entry key="app/src/main/res/layout/item_best_list.xml" value="0.33" />
-        <entry key="app/src/main/res/layout/item_home_header.xml" value="0.5" />
+        <entry key="app/src/main/res/layout/item_home_empty.xml" value="0.375" />
+        <entry key="app/src/main/res/layout/item_home_error.xml" value="0.375" />
+        <entry key="app/src/main/res/layout/item_home_header.xml" value="0.33410672853828305" />
+        <entry key="app/src/main/res/layout/item_home_loading.xml" value="0.375" />
         <entry key="app/src/main/res/layout/item_menu.xml" value="0.33" />
         <entry key="app/src/main/res/layout/layout_home_main_title.xml" value="0.33" />
       </map>

--- a/app/src/main/java/com/example/banchan/domain/model/BestListItem.kt
+++ b/app/src/main/java/com/example/banchan/domain/model/BestListItem.kt
@@ -1,6 +1,14 @@
 package com.example.banchan.domain.model
 
 sealed class BestListItem {
-    object BestHeader : BestListItem()
-    class BestContent(val bestItem: BestModel) : BestListItem()
+    data class BestHeader(
+        val isSubTitleVisible: Boolean = true,
+        val title: String = "한 번 주문하면 \n두 번 반하는 반찬들"
+    ) : BestListItem()
+
+    data class BestContent(val bestItem: BestModel) : BestListItem()
+
+    object BestLoading : BestListItem()
+    object BestError : BestListItem()
+    object BestEmpty : BestListItem()
 }

--- a/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeEmptyViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeEmptyViewHolder.kt
@@ -1,0 +1,6 @@
+package com.example.banchan.presentation.adapter.home
+
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.databinding.ItemHomeEmptyBinding
+
+class HomeEmptyViewHolder(binding: ItemHomeEmptyBinding) : RecyclerView.ViewHolder(binding.root)

--- a/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeErrorViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeErrorViewHolder.kt
@@ -1,0 +1,6 @@
+package com.example.banchan.presentation.adapter.home
+
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.databinding.ItemHomeErrorBinding
+
+class HomeErrorViewHolder(binding: ItemHomeErrorBinding) : RecyclerView.ViewHolder(binding.root)

--- a/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeHeaderViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeHeaderViewHolder.kt
@@ -1,0 +1,13 @@
+package com.example.banchan.presentation.adapter.home
+
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.databinding.ItemHomeHeaderBinding
+
+class HomeHeaderViewHolder(private val binding: ItemHomeHeaderBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(isSubTitleVisible: Boolean, title: String) {
+        binding.title = title
+        binding.isSubtitleVisible = isSubTitleVisible
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeLoadingViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeLoadingViewHolder.kt
@@ -1,0 +1,6 @@
+package com.example.banchan.presentation.adapter.home
+
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.databinding.ItemHomeLoadingBinding
+
+class HomeLoadingViewHolder(binding: ItemHomeLoadingBinding) : RecyclerView.ViewHolder(binding.root)

--- a/app/src/main/java/com/example/banchan/presentation/home/best/BestFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/best/BestFragment.kt
@@ -2,24 +2,43 @@ package com.example.banchan.presentation.home.best
 
 import android.graphics.Rect
 import android.view.View
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentBestBinding
-import com.example.banchan.fakeBestItem
 import com.example.banchan.presentation.base.BaseFragment
-import com.example.banchan.presentation.home.best.adapter.BestListAdapter
+import com.example.banchan.presentation.adapter.best.BestListAdapter
 import com.example.banchan.util.dimen.dpToPx
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class BestFragment : BaseFragment<FragmentBestBinding>(R.layout.fragment_best) {
 
     private val bestListAdapter by lazy { BestListAdapter() }
+    private val bestViewModel: BestViewModel by viewModels()
+
+    override fun onStart() {
+        super.onStart()
+        bestViewModel.getBestDishes()
+    }
 
     override fun initViews() {
         initRecyclerView()
     }
 
     override fun observe() {
-
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                bestViewModel.bestDishes.collectLatest {
+                    bestListAdapter.submitList(it)
+                }
+            }
+        }
     }
 
     private fun initRecyclerView(){
@@ -37,7 +56,6 @@ class BestFragment : BaseFragment<FragmentBestBinding>(R.layout.fragment_best) {
                 else outRect.bottom = dpToPx(requireContext(), 40)
             }
         })
-        bestListAdapter.submitList(fakeBestItem)
     }
 
 }

--- a/app/src/main/java/com/example/banchan/presentation/home/best/BestViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/best/BestViewModel.kt
@@ -1,0 +1,42 @@
+package com.example.banchan.presentation.home.best
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.banchan.domain.model.BestListItem
+import com.example.banchan.domain.usecase.GetBestDishesUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class BestViewModel @Inject constructor(
+    private val getBestDishesUseCase: GetBestDishesUseCase
+) : ViewModel() {
+
+    private val _bestDishes =
+        MutableStateFlow(listOf(BestListItem.BestHeader(), BestListItem.BestLoading))
+    val bestDishes: StateFlow<List<BestListItem>> = _bestDishes
+
+    fun getBestDishes() {
+        _bestDishes.value = listOf(BestListItem.BestHeader(),BestListItem.BestLoading)
+        viewModelScope.launch {
+            getBestDishesUseCase().let { result ->
+                val list = arrayListOf<BestListItem>(BestListItem.BestHeader())
+                if (result.isSuccess) {
+                    if (result.getOrThrow().isEmpty()) list.add(BestListItem.BestEmpty)
+                    else {
+                        result.getOrThrow().map {
+                            list.add(BestListItem.BestContent(it))
+                        }
+                    }
+                    _bestDishes.emit(list)
+                } else {
+                    list.add(BestListItem.BestError)
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/banchan/util/ext/BindingAdapters.kt
+++ b/app/src/main/java/com/example/banchan/util/ext/BindingAdapters.kt
@@ -6,7 +6,6 @@ import com.bumptech.glide.Glide
 
 @BindingAdapter("imageUrl")
 fun ImageView.setImageFromUrl(url: String) {
-    println("야호야호호"+url)
     Glide.with(this.context)
         .load(url)
         .into(this)

--- a/app/src/main/res/drawable/ic_baseline_error_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_error_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="@color/primary_main"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-2h2v2zM13,13h-2L11,7h2v6z"/>
+</vector>

--- a/app/src/main/res/layout/item_home_empty.xml
+++ b/app/src/main/res/layout/item_home_empty.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/tv_home_empty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/home_empty"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_home_error.xml
+++ b/app/src/main/res/layout/item_home_error.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/iv_home_error"
+        android:layout_width="70dp"
+        android:layout_height="70dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_baseline_error_24" />
+
+    <TextView
+        android:id="@+id/tv_home_error"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:text="@string/home_error"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/iv_home_error" />
+
+    <Button
+        android:id="@+id/btn_home_error_reload"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="@string/home_error_btn_reload"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tv_home_error" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_home_header.xml
+++ b/app/src/main/res/layout/item_home_header.xml
@@ -1,33 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:background="@color/primary_surface"
-    android:layout_width="match_parent"
-    android:layout_height="202dp">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <TextView
-        android:id="@+id/tv_home_best_sub_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="36dp"
-        android:background="@drawable/bg_main_subtitle"
-        android:text="@string/home_best_subtitle"
-        android:textSize="10sp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <data>
 
-    <TextView
-        android:id="@+id/tv_home_best_title"
-        android:layout_width="328dp"
-        android:layout_height="wrap_content"
-        android:lineSpacingExtra="2sp"
-        android:text="@string/home_best_title"
-        android:textSize="32sp"
-        android:layout_marginStart="16dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_home_best_sub_title" />
+        <import type="android.view.View"/>
+
+        <variable
+            name="isSubtitleVisible"
+            type="Boolean" />
+
+        <variable
+            name="title"
+            type="String" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:background="@color/primary_surface"
+        android:layout_width="match_parent"
+        android:layout_height="202dp">
+
+        <TextView
+            android:id="@+id/tv_home_best_sub_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="36dp"
+            android:background="@drawable/bg_main_subtitle"
+            android:text="@string/home_best_subtitle"
+            android:visibility="@{isSubtitleVisible ? View.VISIBLE : View.GONE}"
+            android:textSize="10sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_home_best_title"
+            android:layout_width="328dp"
+            android:layout_height="wrap_content"
+            android:lineSpacingExtra="2sp"
+            android:text="@{title}"
+            android:textSize="32sp"
+            android:layout_marginStart="16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_home_best_sub_title" />
 
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_home_loading.xml
+++ b/app/src/main/res/layout/item_home_loading.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ProgressBar
+        android:id="@+id/pb_home_loading"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_menu.xml
+++ b/app/src/main/res/layout/item_menu.xml
@@ -13,15 +13,16 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="168dp"
+        android:layout_height="264dp"
         android:paddingStart="8dp">
 
         <ImageView
             android:id="@+id/iv_banchan"
             imageUrl="@{item.image}"
-            android:layout_width="160dp"
+            android:layout_width="0dp"
             android:layout_height="160dp"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:src="@tools:sample/avatars" />
@@ -38,10 +39,13 @@
         <TextView
             android:id="@+id/tv_title"
             style="@style/tv_normal_14.Black"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
+            android:ellipsize="end"
+            android:maxLines="1"
             android:text="@{item.title}"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/iv_banchan"
             tools:text="오리주물럭" />
@@ -49,10 +53,13 @@
         <TextView
             android:id="@+id/tv_content"
             style="@style/tv_normal_12.GreyDefault"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
             android:text="@{item.description}"
             app:layout_constraintBottom_toTopOf="@id/tv_discount"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_title"
             tools:text="감칠맛 나는 양념" />
@@ -77,6 +84,8 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="7dp"
+            android:ellipsize="end"
+            android:maxLines="1"
             android:text="@{item.discountPercent == null ? item.originPrice : item.discountPrice}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/tv_discount"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,10 @@
     <string name="home_soup_title">정성이 담긴\n뜨끈뜨끈 국물 요리</string>
     <string name="home_side_title">식탁을 풍성하게\n정갈한 밑반찬</string>
 
+    <string name="home_error">데이터 로드에 실패하였습니다.</string>
+    <string name="home_error_btn_reload">다시 시도</string>
+    <string name="home_empty">주문 할 수 있는 음식이 없어요.</string>
+
     <string-array name="home_tab_title_array">
         <item>기획전</item>
         <item>든든한 메인요리</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,7 +6,7 @@
         <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondary">@color/primary_main</item>
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->


### PR DESCRIPTION
## Summary
- Home 화면의 기획전 탭 화면을 실제 데이터와 연동하여 구현합니다.
- Home 화면의 공통 레이아웃을 작성합니다.

## Main Changes
- [x] Home화면의 Header Layout 다른 탭에서도 재사용할 수 있도록 변경
- [x] 홈화면 Loading 화면 Layout
- [x] 홈화면 Error 화면 Layout
- [x] 홈화면 Empty 화면 Layout
- [x] 기획전 탭 API 데이터 수집 및 UI에 반영

Closes #14
