### PR TITLE
[FEAT] 메인, 국물, 반찬 리스트 헤더, 로드 상태 화면 구현 #26

### DIFF
--- a/app/src/main/java/com/example/banchan/domain/model/BestListItem.kt
+++ b/app/src/main/java/com/example/banchan/domain/model/BestListItem.kt
@@ -1,9 +1,12 @@
 package com.example.banchan.domain.model
 
+import androidx.annotation.StringRes
+import com.example.banchan.R
+
 sealed class BestListItem {
     data class BestHeader(
         val isSubTitleVisible: Boolean = true,
-        val title: String = "한 번 주문하면 \n두 번 반하는 반찬들"
+        @StringRes val titleStrRes: Int = R.string.home_best_title
     ) : BestListItem()
 
     data class BestContent(val bestItem: BestModel) : BestListItem()

--- a/app/src/main/java/com/example/banchan/domain/model/ItemModel.kt
+++ b/app/src/main/java/com/example/banchan/domain/model/ItemModel.kt
@@ -1,6 +1,7 @@
 package com.example.banchan.domain.model
 
-import com.example.banchan.presentation.home.maincook.Filter
+import androidx.annotation.StringRes
+import com.example.banchan.R
 import com.example.banchan.presentation.adapter.main.Type
 
 data class ItemModel(
@@ -13,9 +14,3 @@ data class ItemModel(
     val title: String,
     val isCartAdded: Boolean = false
 )
-
-sealed class ItemListModel {
-    data class Header(val currentType: Type, val currentFilter: Filter) : ItemListModel()
-    data class SmallItem(val item: ItemModel) : ItemListModel()
-    data class LargeItem(val item: ItemModel) : ItemListModel()
-}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/best/BestListAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/best/BestListAdapter.kt
@@ -88,7 +88,7 @@ class BestListAdapter :
         getItem(position).let { bestListItem ->
             when (bestListItem) {
                 is BestListItem.BestHeader -> (holder as HomeHeaderViewHolder).bind(
-                    bestListItem.isSubTitleVisible, bestListItem.title
+                    bestListItem.isSubTitleVisible, bestListItem.titleStrRes
                 )
                 is BestListItem.BestLoading -> (holder as HomeLoadingViewHolder)
                 is BestListItem.BestEmpty -> (holder as HomeEmptyViewHolder)

--- a/app/src/main/java/com/example/banchan/presentation/adapter/home/CommonAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/home/CommonAdapter.kt
@@ -1,29 +1,46 @@
 package com.example.banchan.presentation.adapter.home
 
 import android.view.ViewGroup
+import androidx.annotation.StringRes
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.banchan.domain.model.ItemModel
-import com.example.banchan.presentation.home.maincook.Filter
 import com.example.banchan.presentation.adapter.main.MediumMenuViewHolder
+import com.example.banchan.presentation.home.maincook.Filter
 
 class CommonAdapter(private val onFilterChanged: (Filter) -> Unit) :
     ListAdapter<CommonItemListModel, RecyclerView.ViewHolder>(DiffCallback()) {
     override fun getItemViewType(position: Int): Int {
         return when (getItem(position)) {
-            is CommonItemListModel.Header -> HEADER_VIEW_TYPE
+            is CommonItemListModel.CommonHeader -> HEADER_VIEW_TYPE
+            is CommonItemListModel.Filter -> FILTER_VIEW_TYPE
             is CommonItemListModel.SmallItem -> MEDIUM_ITEM_VIEW_TYPE
+            is CommonItemListModel.Loading -> LOADING_VIEW_TYPE
+            is CommonItemListModel.Error -> ERROR_VIEW_TYPE
+            is CommonItemListModel.Empty -> EMPTY_VIEW_TYPE
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
             HEADER_VIEW_TYPE -> {
+                HomeHeaderViewHolder.create(parent)
+            }
+            FILTER_VIEW_TYPE -> {
                 CommonFilterViewViewHolder.create(parent)
             }
             MEDIUM_ITEM_VIEW_TYPE -> {
                 MediumMenuViewHolder.create(parent)
+            }
+            LOADING_VIEW_TYPE -> {
+                HomeLoadingViewHolder.create(parent)
+            }
+            ERROR_VIEW_TYPE -> {
+                HomeLoadingViewHolder.create(parent)
+            }
+            EMPTY_VIEW_TYPE -> {
+                HomeEmptyViewHolder.create(parent)
             }
             else -> {
                 throw UnsupportedOperationException("Unknown view")
@@ -33,7 +50,10 @@ class CommonAdapter(private val onFilterChanged: (Filter) -> Unit) :
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (val item = getItem(position)) {
-            is CommonItemListModel.Header ->
+            is CommonItemListModel.CommonHeader -> {
+                (holder as HomeHeaderViewHolder).bind(titleStrRes = item.titleStrRes, isSubTitleVisible = false)
+            }
+            is CommonItemListModel.Filter ->
                 (holder as CommonFilterViewViewHolder).bind(
                     item.currentFilter,
                     item.total,
@@ -42,19 +62,26 @@ class CommonAdapter(private val onFilterChanged: (Filter) -> Unit) :
             is CommonItemListModel.SmallItem -> {
                 (holder as MediumMenuViewHolder).bind(item.item) {}
             }
+            else -> {
+
+            }
         }
     }
 
     companion object {
         const val HEADER_VIEW_TYPE = 0
-        const val MEDIUM_ITEM_VIEW_TYPE = 1
+        const val FILTER_VIEW_TYPE = 1
+        const val MEDIUM_ITEM_VIEW_TYPE = 2
+        const val LOADING_VIEW_TYPE = 3
+        const val ERROR_VIEW_TYPE = 4
+        const val EMPTY_VIEW_TYPE = 5
 
         class DiffCallback : DiffUtil.ItemCallback<CommonItemListModel>() {
             override fun areItemsTheSame(
                 oldItem: CommonItemListModel,
                 newItem: CommonItemListModel
             ): Boolean {
-                return (oldItem is CommonItemListModel.Header && newItem is CommonItemListModel.Header &&
+                return (oldItem is CommonItemListModel.Filter && newItem is CommonItemListModel.Filter &&
                         oldItem.total == newItem.total) ||
                         (oldItem is CommonItemListModel.SmallItem && newItem is CommonItemListModel.SmallItem &&
                                 oldItem.item.detailHash == newItem.item.detailHash)
@@ -71,6 +98,19 @@ class CommonAdapter(private val onFilterChanged: (Filter) -> Unit) :
 }
 
 sealed class CommonItemListModel {
-    data class Header(val total: Int, val currentFilter: Filter) : CommonItemListModel()
+    data class CommonHeader(
+        val isSubTitleVisible: Boolean = false,
+        @StringRes val titleStrRes: Int
+    ) : CommonItemListModel()
+
+    data class Filter(
+        val total: Int,
+        val currentFilter: com.example.banchan.presentation.home.maincook.Filter
+    ) : CommonItemListModel()
+
     data class SmallItem(val item: ItemModel) : CommonItemListModel()
+
+    object Loading : CommonItemListModel()
+    object Error : CommonItemListModel()
+    object Empty : CommonItemListModel()
 }

--- a/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeEmptyViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeEmptyViewHolder.kt
@@ -1,6 +1,18 @@
 package com.example.banchan.presentation.adapter.home
 
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.example.banchan.databinding.ItemHomeEmptyBinding
 
-class HomeEmptyViewHolder(binding: ItemHomeEmptyBinding) : RecyclerView.ViewHolder(binding.root)
+class HomeEmptyViewHolder(binding: ItemHomeEmptyBinding) : RecyclerView.ViewHolder(binding.root) {
+    companion object {
+        fun create(parent: ViewGroup) = HomeEmptyViewHolder(
+            ItemHomeEmptyBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeErrorViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeErrorViewHolder.kt
@@ -1,6 +1,18 @@
 package com.example.banchan.presentation.adapter.home
 
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.example.banchan.databinding.ItemHomeErrorBinding
 
-class HomeErrorViewHolder(binding: ItemHomeErrorBinding) : RecyclerView.ViewHolder(binding.root)
+class HomeErrorViewHolder(binding: ItemHomeErrorBinding) : RecyclerView.ViewHolder(binding.root) {
+    companion object {
+        fun create(parent: ViewGroup) = HomeErrorViewHolder(
+            ItemHomeErrorBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeHeaderViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeHeaderViewHolder.kt
@@ -1,13 +1,25 @@
 package com.example.banchan.presentation.adapter.home
 
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.example.banchan.databinding.ItemHomeHeaderBinding
 
 class HomeHeaderViewHolder(private val binding: ItemHomeHeaderBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(isSubTitleVisible: Boolean, title: String) {
-        binding.title = title
+    fun bind(isSubTitleVisible: Boolean, titleStrRes: Int) {
+        binding.title = binding.root.resources.getString(titleStrRes)
         binding.isSubtitleVisible = isSubTitleVisible
+    }
+
+    companion object {
+        fun create(parent: ViewGroup) = HomeHeaderViewHolder(
+            ItemHomeHeaderBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
     }
 }

--- a/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeLoadingViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/home/HomeLoadingViewHolder.kt
@@ -1,6 +1,19 @@
 package com.example.banchan.presentation.adapter.home
 
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.example.banchan.databinding.ItemHomeLoadingBinding
 
-class HomeLoadingViewHolder(binding: ItemHomeLoadingBinding) : RecyclerView.ViewHolder(binding.root)
+class HomeLoadingViewHolder(binding: ItemHomeLoadingBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+    companion object {
+        fun create(parent: ViewGroup) = HomeLoadingViewHolder(
+            ItemHomeLoadingBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/main/CommonSpacingItemDecorator.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/main/CommonSpacingItemDecorator.kt
@@ -4,7 +4,7 @@ import android.graphics.Rect
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 
-class SpacingItemDecorator(private val padding: Int) : RecyclerView.ItemDecoration() {
+class CommonSpacingItemDecorator(private val padding: Int) : RecyclerView.ItemDecoration() {
     override fun getItemOffsets(
         outRect: Rect,
         view: View,
@@ -13,7 +13,8 @@ class SpacingItemDecorator(private val padding: Int) : RecyclerView.ItemDecorati
     ) {
         super.getItemOffsets(outRect, view, parent, state)
 
-        if (parent.getChildAdapterPosition(view) != 0) {
+        val position = parent.getChildAdapterPosition(view)
+        if (position != 0) {
             outRect.top = padding
             outRect.bottom = padding
             outRect.left = padding

--- a/app/src/main/java/com/example/banchan/presentation/adapter/main/GridSpacingItemDecorator.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/main/GridSpacingItemDecorator.kt
@@ -1,0 +1,40 @@
+package com.example.banchan.presentation.adapter.main
+
+import android.graphics.Rect
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+class GridSpacingItemDecorator(private val padding: Int) : RecyclerView.ItemDecoration() {
+    override fun getItemOffsets(
+        outRect: Rect,
+        view: View,
+        parent: RecyclerView,
+        state: RecyclerView.State
+    ) {
+        super.getItemOffsets(outRect, view, parent, state)
+
+        when (val position = parent.getChildAdapterPosition(view)) {
+            0 -> {}
+            1 -> {
+                outRect.top = padding
+                outRect.bottom = padding
+                outRect.left = padding
+                outRect.right = padding
+            }
+            else -> {
+                val col = position % 2
+
+                outRect.top = padding
+                outRect.bottom = padding
+
+                if (col == 0) {
+                    outRect.left = padding
+                    outRect.right = padding / 2
+                } else {
+                    outRect.left = padding / 2
+                    outRect.right = padding
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/main/MainAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/main/MainAdapter.kt
@@ -1,29 +1,44 @@
 package com.example.banchan.presentation.adapter.main
 
 import android.view.ViewGroup
+import androidx.annotation.StringRes
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.example.banchan.domain.model.ItemListModel
+import com.example.banchan.R
+import com.example.banchan.domain.model.ItemModel
+import com.example.banchan.presentation.adapter.home.HomeEmptyViewHolder
+import com.example.banchan.presentation.adapter.home.HomeHeaderViewHolder
+import com.example.banchan.presentation.adapter.home.HomeLoadingViewHolder
 import com.example.banchan.presentation.home.maincook.Filter
 
 enum class Type {
     Grid, Linear
 }
 
-class MainAdapter(private val onTypeChanged: (Type) -> Unit, private val onFilterChanged: (Filter) -> Unit) :
-    ListAdapter<ItemListModel, RecyclerView.ViewHolder>(DiffCallback()) {
+class MainAdapter(
+    private val onTypeChanged: (Type) -> Unit,
+    private val onFilterChanged: (Filter) -> Unit
+) :
+    ListAdapter<MainItemListModel, RecyclerView.ViewHolder>(DiffCallback()) {
     override fun getItemViewType(position: Int): Int {
         return when (getItem(position)) {
-            is ItemListModel.Header -> HEADER_VIEW_TYPE
-            is ItemListModel.LargeItem -> LARGE_ITEM_VIEW_TYPE
-            is ItemListModel.SmallItem -> MEDIUM_ITEM_VIEW_TYPE
+            is MainItemListModel.MainHeader -> HEADER_VIEW_TYPE
+            is MainItemListModel.Filter -> FILTER_VIEW_TYPE
+            is MainItemListModel.LargeItem -> LARGE_ITEM_VIEW_TYPE
+            is MainItemListModel.SmallItem -> MEDIUM_ITEM_VIEW_TYPE
+            is MainItemListModel.Loading -> LOADING_VIEW_TYPE
+            is MainItemListModel.Error -> ERROR_VIEW_TYPE
+            is MainItemListModel.Empty -> EMPTY_VIEW_TYPE
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
             HEADER_VIEW_TYPE -> {
+                HomeHeaderViewHolder.create(parent)
+            }
+            FILTER_VIEW_TYPE -> {
                 MainFilterViewHolder.create(parent)
             }
             LARGE_ITEM_VIEW_TYPE -> {
@@ -31,6 +46,15 @@ class MainAdapter(private val onTypeChanged: (Type) -> Unit, private val onFilte
             }
             MEDIUM_ITEM_VIEW_TYPE -> {
                 MediumMenuViewHolder.create(parent)
+            }
+            LOADING_VIEW_TYPE -> {
+                HomeLoadingViewHolder.create(parent)
+            }
+            ERROR_VIEW_TYPE -> {
+                HomeLoadingViewHolder.create(parent)
+            }
+            EMPTY_VIEW_TYPE -> {
+                HomeEmptyViewHolder.create(parent)
             }
             else -> {
                 throw UnsupportedOperationException("Unknown view")
@@ -40,41 +64,76 @@ class MainAdapter(private val onTypeChanged: (Type) -> Unit, private val onFilte
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (val item = getItem(position)) {
-            is ItemListModel.Header ->
-                (holder as MainFilterViewHolder).bind(item.currentType, onTypeChanged, item.currentFilter, onFilterChanged)
-            is ItemListModel.LargeItem -> {
+            is MainItemListModel.MainHeader -> {
+                (holder as HomeHeaderViewHolder).bind(
+                    item.isSubTitleVisible, item.titleStrRes
+                )
+            }
+            is MainItemListModel.Filter ->
+                (holder as MainFilterViewHolder).bind(
+                    item.currentType,
+                    onTypeChanged,
+                    item.currentFilter,
+                    onFilterChanged
+                )
+            is MainItemListModel.LargeItem -> {
                 (holder as LargeMenuViewHolder).bind(item.item) {}
             }
-            is ItemListModel.SmallItem -> {
+            is MainItemListModel.SmallItem -> {
                 (holder as MediumMenuViewHolder).bind(item.item) {}
+            }
+            else -> {
+
             }
         }
     }
 
     companion object {
         const val HEADER_VIEW_TYPE = 0
-        const val LARGE_ITEM_VIEW_TYPE = 1
-        const val MEDIUM_ITEM_VIEW_TYPE = 2
+        const val FILTER_VIEW_TYPE = 1
+        const val LARGE_ITEM_VIEW_TYPE = 2
+        const val MEDIUM_ITEM_VIEW_TYPE = 3
+        const val LOADING_VIEW_TYPE = 4
+        const val ERROR_VIEW_TYPE = 5
+        const val EMPTY_VIEW_TYPE = 6
 
-        class DiffCallback : DiffUtil.ItemCallback<ItemListModel>() {
+        class DiffCallback : DiffUtil.ItemCallback<MainItemListModel>() {
             override fun areItemsTheSame(
-                oldItem: ItemListModel,
-                newItem: ItemListModel
+                oldItem: MainItemListModel,
+                newItem: MainItemListModel
             ): Boolean {
-                return (oldItem is ItemListModel.Header && newItem is ItemListModel.Header &&
+                return (oldItem is MainItemListModel.Filter && newItem is MainItemListModel.Filter &&
                         oldItem.currentType == newItem.currentType) ||
-                        (oldItem is ItemListModel.SmallItem && newItem is ItemListModel.SmallItem &&
+                        (oldItem is MainItemListModel.SmallItem && newItem is MainItemListModel.SmallItem &&
                                 oldItem.item.detailHash == newItem.item.detailHash) ||
-                        (oldItem is ItemListModel.LargeItem && newItem is ItemListModel.LargeItem &&
+                        (oldItem is MainItemListModel.LargeItem && newItem is MainItemListModel.LargeItem &&
                                 oldItem.item.detailHash == newItem.item.detailHash)
             }
 
             override fun areContentsTheSame(
-                oldItem: ItemListModel,
-                newItem: ItemListModel
+                oldItem: MainItemListModel,
+                newItem: MainItemListModel
             ): Boolean {
                 return oldItem == newItem
             }
         }
     }
+}
+
+sealed class MainItemListModel {
+    data class MainHeader(
+        val isSubTitleVisible: Boolean = false,
+        @StringRes val titleStrRes: Int = R.string.home_main_cook_title
+    ) : MainItemListModel()
+
+    data class Filter(
+        val currentType: Type,
+        val currentFilter: com.example.banchan.presentation.home.maincook.Filter
+    ) : MainItemListModel()
+
+    data class SmallItem(val item: ItemModel) : MainItemListModel()
+    data class LargeItem(val item: ItemModel) : MainItemListModel()
+    object Loading : MainItemListModel()
+    object Error : MainItemListModel()
+    object Empty : MainItemListModel()
 }

--- a/app/src/main/java/com/example/banchan/presentation/adapter/main/SpacingItemDecorator.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/main/SpacingItemDecorator.kt
@@ -12,9 +12,12 @@ class SpacingItemDecorator(private val padding: Int) : RecyclerView.ItemDecorati
         state: RecyclerView.State
     ) {
         super.getItemOffsets(outRect, view, parent, state)
-        outRect.top = padding
-        outRect.bottom = padding
-        outRect.left = padding
-        outRect.right = padding
+
+        if (parent.getChildAdapterPosition(view) != 0) {
+            outRect.top = padding
+            outRect.bottom = padding
+            outRect.left = padding
+            outRect.right = padding
+        }
     }
 }

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookFragment.kt
@@ -8,11 +8,10 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentMainCookBinding
-import com.example.banchan.domain.model.ItemListModel
-import com.example.banchan.presentation.base.BaseFragment
 import com.example.banchan.presentation.adapter.main.MainAdapter
 import com.example.banchan.presentation.adapter.main.SpacingItemDecorator
 import com.example.banchan.presentation.adapter.main.Type
+import com.example.banchan.presentation.base.BaseFragment
 import com.example.banchan.util.dimen.dpToPx
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -23,8 +22,12 @@ class MainCookFragment : BaseFragment<FragmentMainCookBinding>(R.layout.fragment
 
     private val mainAdapter by lazy {
         MainAdapter(
-            onTypeChanged = { viewModel.changeType(it) },
-            onFilterChanged = { viewModel.changeFilter(it) }
+            onTypeChanged = {
+                viewModel.changeType(it)
+            },
+            onFilterChanged = {
+                viewModel.changeFilter(it)
+            }
         )
     }
 
@@ -40,9 +43,9 @@ class MainCookFragment : BaseFragment<FragmentMainCookBinding>(R.layout.fragment
     override fun observe() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.menus.collect {
+                viewModel.dishes.collect {
                     mainAdapter.submitList(it) {
-                        changeListType((it[0] as ItemListModel.Header).currentType)
+                        changeListType(viewModel.type)
                     }
                 }
             }
@@ -60,7 +63,7 @@ class MainCookFragment : BaseFragment<FragmentMainCookBinding>(R.layout.fragment
                     object : GridLayoutManager.SpanSizeLookup() {
                         override fun getSpanSize(position: Int): Int {
                             return when (mainAdapter.getItemViewType(position)) {
-                                MainAdapter.HEADER_VIEW_TYPE -> 2
+                                MainAdapter.HEADER_VIEW_TYPE, MainAdapter.FILTER_VIEW_TYPE, MainAdapter.EMPTY_VIEW_TYPE, MainAdapter.ERROR_VIEW_TYPE, MainAdapter.LOADING_VIEW_TYPE -> 2
                                 else -> 1
                             }
                         }

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookFragment.kt
@@ -8,8 +8,9 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentMainCookBinding
+import com.example.banchan.presentation.adapter.main.CommonSpacingItemDecorator
+import com.example.banchan.presentation.adapter.main.GridSpacingItemDecorator
 import com.example.banchan.presentation.adapter.main.MainAdapter
-import com.example.banchan.presentation.adapter.main.SpacingItemDecorator
 import com.example.banchan.presentation.adapter.main.Type
 import com.example.banchan.presentation.base.BaseFragment
 import com.example.banchan.util.dimen.dpToPx
@@ -35,7 +36,6 @@ class MainCookFragment : BaseFragment<FragmentMainCookBinding>(R.layout.fragment
         binding.rvMain.apply {
             adapter = mainAdapter
             itemAnimator = null
-            addItemDecoration(SpacingItemDecorator(dpToPx(requireActivity(), 4)))
         }
         changeListType(Type.Grid)
     }
@@ -52,13 +52,42 @@ class MainCookFragment : BaseFragment<FragmentMainCookBinding>(R.layout.fragment
         }
     }
 
+    private val commonSpacingItemDecorator by lazy {
+        CommonSpacingItemDecorator(
+            dpToPx(
+                requireActivity(),
+                12
+            )
+        )
+    }
+    private val gridSpacingItemDecorator by lazy {
+        GridSpacingItemDecorator(
+            dpToPx(
+                requireActivity(),
+                12
+            )
+        )
+    }
+
     private fun changeListType(type: Type) {
         when (type) {
             Type.Linear -> {
-                binding.rvMain.layoutManager = LinearLayoutManager(requireActivity())
+                binding.rvMain.apply {
+                    layoutManager = LinearLayoutManager(requireActivity())
+                    if (itemDecorationCount != 0) {
+                        removeItemDecorationAt(0)
+                    }
+                    addItemDecoration(commonSpacingItemDecorator)
+                }
             }
             Type.Grid -> {
-                binding.rvMain.layoutManager = GridLayoutManager(requireActivity(), 2)
+                binding.rvMain.apply {
+                    layoutManager = GridLayoutManager(requireActivity(), 2)
+                    if (itemDecorationCount != 0) {
+                        removeItemDecorationAt(0)
+                    }
+                    addItemDecoration(gridSpacingItemDecorator)
+                }
                 (binding.rvMain.layoutManager as GridLayoutManager).spanSizeLookup =
                     object : GridLayoutManager.SpanSizeLookup() {
                         override fun getSpanSize(position: Int): Int {

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookViewModel.kt
@@ -2,13 +2,13 @@ package com.example.banchan.presentation.home.maincook
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.banchan.domain.model.ItemListModel
 import com.example.banchan.domain.usecase.GetMainDishesUseCase
+import com.example.banchan.presentation.adapter.main.MainItemListModel
 import com.example.banchan.presentation.adapter.main.Type
 import com.example.banchan.util.ext.toNum
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -16,41 +16,60 @@ import javax.inject.Inject
 class MainCookViewModel @Inject constructor(
     private val getMainDishesUseCase: GetMainDishesUseCase
 ) : ViewModel() {
-    private val type = MutableStateFlow(Type.Grid)
-    private val filter = MutableStateFlow(Filter.NORMAL)
-    val menus = combine(type, filter) { type, filter ->
-        listOf(ItemListModel.Header(type, filter)) + getMainDishesUseCase()
-            .run {
-                when (filter) {
-                    Filter.PRICE_LOW -> this.sortedWith(compareBy {
-                        it.discountPrice.toNum() ?: it.originPrice.toNum()
-                    })
-                    Filter.PRICE_HIGH -> this.sortedWith(compareByDescending {
-                        it.discountPrice.toNum() ?: it.originPrice.toNum()
-                    })
-                    Filter.SALE -> this.sortedByDescending { it.discountPercent }
-                    else -> this
-                }
+    var type = Type.Grid
+        private set
+    private var filter = Filter.NORMAL
+    private val _dishes =
+        MutableStateFlow(listOf(MainItemListModel.MainHeader(), MainItemListModel.Loading))
+    val dishes = _dishes.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _dishes.emit(makeItemModel(type, filter))
+        }
+    }
+
+    fun changeType(changedType: Type) {
+        viewModelScope.launch {
+            type = changedType
+            _dishes.emit(makeItemModel(type, filter))
+        }
+    }
+
+    fun changeFilter(changedFilter: Filter) {
+        viewModelScope.launch {
+            filter = changedFilter
+            _dishes.emit(makeItemModel(type, filter))
+        }
+    }
+
+    private suspend fun makeItemModel(type: Type, filter: Filter): List<MainItemListModel> {
+        val result = getMainDishesUseCase()
+        val preList = mutableListOf(
+            MainItemListModel.MainHeader(),
+            MainItemListModel.Filter(type, filter)
+        )
+        if (result.isEmpty()) preList.add(MainItemListModel.Empty)
+
+        return preList + result.run {
+            when (filter) {
+                Filter.PRICE_LOW -> sortedWith(compareBy {
+                    it.discountPrice.toNum() ?: it.originPrice.toNum()
+                })
+                Filter.PRICE_HIGH -> sortedWith(compareByDescending {
+                    it.discountPrice.toNum() ?: it.originPrice.toNum()
+                })
+                Filter.SALE -> this.sortedByDescending { it.discountPercent }
+                else -> this
             }
+        }
             .map {
                 if (type == Type.Grid) {
-                    ItemListModel.SmallItem(it)
+                    MainItemListModel.SmallItem(it)
                 } else {
-                    ItemListModel.LargeItem(it)
+                    MainItemListModel.LargeItem(it)
                 }
             }
-    }
-
-    fun changeType(type: Type) {
-        viewModelScope.launch {
-            this@MainCookViewModel.type.emit(type)
-        }
-    }
-
-    fun changeFilter(filter: Filter) {
-        viewModelScope.launch {
-            this@MainCookViewModel.filter.emit(filter)
-        }
     }
 }
 

--- a/app/src/main/java/com/example/banchan/presentation/home/side/SideFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/side/SideFragment.kt
@@ -35,7 +35,7 @@ class SideFragment : BaseFragment<FragmentSoupBinding>(R.layout.fragment_soup) {
             object : GridLayoutManager.SpanSizeLookup() {
                 override fun getSpanSize(position: Int): Int {
                     return when (sideAdapter.getItemViewType(position)) {
-                        MainAdapter.HEADER_VIEW_TYPE -> 2
+                        CommonAdapter.HEADER_VIEW_TYPE, CommonAdapter.FILTER_VIEW_TYPE, CommonAdapter.EMPTY_VIEW_TYPE, CommonAdapter.ERROR_VIEW_TYPE, CommonAdapter.LOADING_VIEW_TYPE -> 2
                         else -> 1
                     }
                 }
@@ -45,7 +45,7 @@ class SideFragment : BaseFragment<FragmentSoupBinding>(R.layout.fragment_soup) {
     override fun observe() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.menus.collect {
+                viewModel.dishes.collect {
                     sideAdapter.submitList(it)
                 }
             }

--- a/app/src/main/java/com/example/banchan/presentation/home/side/SideFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/side/SideFragment.kt
@@ -8,8 +8,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentSoupBinding
 import com.example.banchan.presentation.base.BaseFragment
-import com.example.banchan.presentation.adapter.main.MainAdapter
-import com.example.banchan.presentation.adapter.main.SpacingItemDecorator
+import com.example.banchan.presentation.adapter.main.GridSpacingItemDecorator
 import com.example.banchan.presentation.adapter.home.CommonAdapter
 import com.example.banchan.util.dimen.dpToPx
 import dagger.hilt.android.AndroidEntryPoint
@@ -28,7 +27,7 @@ class SideFragment : BaseFragment<FragmentSoupBinding>(R.layout.fragment_soup) {
         binding.rvSoup.apply {
             adapter = sideAdapter
             itemAnimator = null
-            addItemDecoration(SpacingItemDecorator(dpToPx(requireActivity(), 4)))
+            addItemDecoration(GridSpacingItemDecorator(dpToPx(requireActivity(), 12)))
         }
 
         (binding.rvSoup.layoutManager as GridLayoutManager).spanSizeLookup =

--- a/app/src/main/java/com/example/banchan/presentation/home/soup/SoupFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/soup/SoupFragment.kt
@@ -7,10 +7,9 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentSoupBinding
-import com.example.banchan.presentation.base.BaseFragment
-import com.example.banchan.presentation.adapter.main.MainAdapter
-import com.example.banchan.presentation.adapter.main.SpacingItemDecorator
 import com.example.banchan.presentation.adapter.home.CommonAdapter
+import com.example.banchan.presentation.adapter.main.SpacingItemDecorator
+import com.example.banchan.presentation.base.BaseFragment
 import com.example.banchan.util.dimen.dpToPx
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -35,7 +34,7 @@ class SoupFragment : BaseFragment<FragmentSoupBinding>(R.layout.fragment_soup) {
             object : GridLayoutManager.SpanSizeLookup() {
                 override fun getSpanSize(position: Int): Int {
                     return when (soupAdapter.getItemViewType(position)) {
-                        MainAdapter.HEADER_VIEW_TYPE -> 2
+                        CommonAdapter.HEADER_VIEW_TYPE, CommonAdapter.FILTER_VIEW_TYPE, CommonAdapter.EMPTY_VIEW_TYPE, CommonAdapter.ERROR_VIEW_TYPE, CommonAdapter.LOADING_VIEW_TYPE -> 2
                         else -> 1
                     }
                 }
@@ -45,7 +44,7 @@ class SoupFragment : BaseFragment<FragmentSoupBinding>(R.layout.fragment_soup) {
     override fun observe() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.menus.collect {
+                viewModel.dishes.collect {
                     soupAdapter.submitList(it)
                 }
             }

--- a/app/src/main/java/com/example/banchan/presentation/home/soup/SoupFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/soup/SoupFragment.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentSoupBinding
 import com.example.banchan.presentation.adapter.home.CommonAdapter
-import com.example.banchan.presentation.adapter.main.SpacingItemDecorator
+import com.example.banchan.presentation.adapter.main.GridSpacingItemDecorator
 import com.example.banchan.presentation.base.BaseFragment
 import com.example.banchan.util.dimen.dpToPx
 import dagger.hilt.android.AndroidEntryPoint
@@ -27,7 +27,7 @@ class SoupFragment : BaseFragment<FragmentSoupBinding>(R.layout.fragment_soup) {
         binding.rvSoup.apply {
             adapter = soupAdapter
             itemAnimator = null
-            addItemDecoration(SpacingItemDecorator(dpToPx(requireActivity(), 4)))
+            addItemDecoration(GridSpacingItemDecorator(dpToPx(requireActivity(), 12)))
         }
 
         (binding.rvSoup.layoutManager as GridLayoutManager).spanSizeLookup =

--- a/app/src/main/java/com/example/banchan/presentation/home/soup/SoupViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/soup/SoupViewModel.kt
@@ -2,13 +2,14 @@ package com.example.banchan.presentation.home.soup
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.banchan.R
 import com.example.banchan.domain.usecase.GetSoupDishesUseCase
-import com.example.banchan.presentation.home.maincook.Filter
 import com.example.banchan.presentation.adapter.home.CommonItemListModel
+import com.example.banchan.presentation.home.maincook.Filter
 import com.example.banchan.util.ext.toNum
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -16,10 +17,38 @@ import javax.inject.Inject
 class SoupViewModel @Inject constructor(
     private val getSoupDishesUseCase: GetSoupDishesUseCase
 ) : ViewModel() {
-    private val filter = MutableStateFlow(Filter.NORMAL)
-    val menus = filter.map { filter ->
+    private var filter = Filter.NORMAL
+    private val _dishes =
+        MutableStateFlow(
+            listOf(
+                CommonItemListModel.CommonHeader(titleStrRes = R.string.home_soup_title),
+                CommonItemListModel.Loading
+            )
+        )
+    val dishes = _dishes.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _dishes.emit(makeItemModel(filter))
+        }
+    }
+
+    fun changeFilter(changedFilter: Filter) {
+        viewModelScope.launch {
+            filter = changedFilter
+            _dishes.emit(makeItemModel(filter))
+        }
+    }
+
+    private suspend fun makeItemModel(filter: Filter): List<CommonItemListModel> {
         val soupDishes = getSoupDishesUseCase()
-        listOf(CommonItemListModel.Header(soupDishes.size, filter)) + soupDishes.run {
+        val preList = mutableListOf(
+            CommonItemListModel.CommonHeader(titleStrRes = R.string.home_soup_title),
+            CommonItemListModel.Filter(soupDishes.size, filter)
+        )
+        if (soupDishes.isEmpty()) preList.add(CommonItemListModel.Empty)
+
+        return preList + soupDishes.run {
             when (filter) {
                 Filter.PRICE_LOW -> sortedWith(compareBy {
                     it.discountPrice.toNum() ?: it.originPrice.toNum()
@@ -32,12 +61,6 @@ class SoupViewModel @Inject constructor(
             }
         }.map {
             CommonItemListModel.SmallItem(it)
-        }
-    }
-
-    fun changeFilter(filter: Filter) {
-        viewModelScope.launch {
-            this@SoupViewModel.filter.emit(filter)
         }
     }
 }

--- a/app/src/main/res/layout/fragment_main_cook.xml
+++ b/app/src/main/res/layout/fragment_main_cook.xml
@@ -15,7 +15,6 @@
             android:id="@+id/rv_main"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:padding="12dp"
             tools:listitem="@layout/item_menu" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_side.xml
+++ b/app/src/main/res/layout/fragment_side.xml
@@ -16,7 +16,6 @@
             android:id="@+id/rv_side"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:padding="12dp"
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:spanCount="2" />
 

--- a/app/src/main/res/layout/fragment_soup.xml
+++ b/app/src/main/res/layout/fragment_soup.xml
@@ -16,7 +16,6 @@
             android:id="@+id/rv_soup"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:padding="12dp"
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:spanCount="2" />
 


### PR DESCRIPTION
## Summary
메인, 국물, 반찬 리스트 헤더, 로드 상태 화면 구현

## Main Changes
- 메인, 국물, 반찬 헤더 구현
- 메인, 국물, 반찬 로드 상태 화면 구현

<img src="https://user-images.githubusercontent.com/54823396/184271289-00f01929-2dda-4e73-a8e3-eff426f52f6f.png" width="30%" /> <img src="https://user-images.githubusercontent.com/54823396/184274962-deee07a8-c03b-4943-b0ec-ba285bcea0fa.png" width="30%" /> <img src="https://user-images.githubusercontent.com/54823396/184271350-7e389d93-068f-490d-aada-3d8013e10a11.png" width="30%" />

Closes #26 
