### PR TITLE
[FEAT] 장바구니 DB 구현, 쿼리 추가 #29

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,6 +69,6 @@ dependencies {
     implementation "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:$kotlinx_serialization_converter"
 
     // room
-    implementation "androidx.room:room-runtime:$room_version"
-    annotationProcessor "androidx.room:room-compiler:$room_version"
+    implementation "androidx.room:room-ktx:$room_version"
+    kapt "androidx.room:room-compiler:$room_version"
 }

--- a/app/src/main/java/com/example/banchan/data/repository/BasketRepository.kt
+++ b/app/src/main/java/com/example/banchan/data/repository/BasketRepository.kt
@@ -1,0 +1,10 @@
+package com.example.banchan.data.repository
+
+import com.example.banchan.data.source.local.BasketItem
+import kotlinx.coroutines.flow.Flow
+
+interface BasketRepository {
+    fun getBasketItems(): Flow<List<BasketItem>>
+    suspend fun insertBasketItem(vararg basketItem: BasketItem)
+    suspend fun updateBasketItem(vararg basketItem: BasketItem)
+}

--- a/app/src/main/java/com/example/banchan/data/repository/BasketRepositoryImpl.kt
+++ b/app/src/main/java/com/example/banchan/data/repository/BasketRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.example.banchan.data.repository
+
+import com.example.banchan.data.source.local.BasketItem
+import com.example.banchan.data.source.local.BasketLocalDataSource
+import javax.inject.Inject
+
+class BasketRepositoryImpl @Inject constructor(
+    private val localDataSource: BasketLocalDataSource
+) : BasketRepository {
+    override fun getBasketItems() = localDataSource.getBasketItems()
+
+    override suspend fun insertBasketItem(vararg basketItem: BasketItem) {
+        localDataSource.insertBasketItem(*basketItem)
+    }
+
+    override suspend fun updateBasketItem(vararg basketItem: BasketItem) {
+        localDataSource.updateBasketItem(*basketItem)
+    }
+}

--- a/app/src/main/java/com/example/banchan/data/source/BanChanDataSource.kt
+++ b/app/src/main/java/com/example/banchan/data/source/BanChanDataSource.kt
@@ -1,4 +1,4 @@
-package com.example.banchan.data.source.remote
+package com.example.banchan.data.source
 
 import com.example.banchan.data.response.detail.DetailResponse
 import com.example.banchan.data.response.main.MainResponse
@@ -7,14 +7,9 @@ import com.example.banchan.data.response.soup.SoupResponse
 import com.example.banchan.domain.model.BestModel
 
 interface BanChanDataSource {
-
     suspend fun getBest(): Result<List<BestModel>>
-
     suspend fun getMain(): Result<MainResponse>
-
     suspend fun getSoup(): Result<SoupResponse>
-
     suspend fun getSide(): Result<SideResponse>
-
     suspend fun getDetail(hash: String): Result<DetailResponse>
 }

--- a/app/src/main/java/com/example/banchan/data/source/BasketDataSource.kt
+++ b/app/src/main/java/com/example/banchan/data/source/BasketDataSource.kt
@@ -1,0 +1,10 @@
+package com.example.banchan.data.source
+
+import com.example.banchan.data.source.local.BasketItem
+import kotlinx.coroutines.flow.Flow
+
+interface BasketDataSource {
+    fun getBasketItems(): Flow<List<BasketItem>>
+    suspend fun insertBasketItem(vararg basketItem: BasketItem)
+    suspend fun updateBasketItem(vararg basketItem: BasketItem)
+}

--- a/app/src/main/java/com/example/banchan/data/source/local/BanChanDatabase.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/BanChanDatabase.kt
@@ -1,0 +1,9 @@
+package com.example.banchan.data.source.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(entities = [BasketItem::class], version = 1, exportSchema = false)
+abstract class BanChanDatabase : RoomDatabase() {
+    abstract fun basketDao(): BasketDao
+}

--- a/app/src/main/java/com/example/banchan/data/source/local/BasketDao.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/BasketDao.kt
@@ -1,0 +1,16 @@
+package com.example.banchan.data.source.local
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface BasketDao {
+    @Query("SELECT * FROM basketitem")
+    fun getBasketItems(): Flow<List<BasketItem>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertBasketItem(vararg basketItem: BasketItem)
+
+    @Update
+    fun updateBasketItem(vararg basketItem: BasketItem)
+}

--- a/app/src/main/java/com/example/banchan/data/source/local/BasketItem.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/BasketItem.kt
@@ -1,0 +1,12 @@
+package com.example.banchan.data.source.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
+data class BasketItem(
+    @PrimaryKey
+    val hash: String,
+    val count: Int,
+    val isSelected: Boolean
+)

--- a/app/src/main/java/com/example/banchan/data/source/local/BasketLocalDataSource.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/BasketLocalDataSource.kt
@@ -1,0 +1,26 @@
+package com.example.banchan.data.source.local
+
+import com.example.banchan.data.source.BasketDataSource
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class BasketLocalDataSource @Inject constructor(
+    private val basketDao: BasketDao,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : BasketDataSource {
+    override fun getBasketItems() = basketDao.getBasketItems()
+
+    override suspend fun insertBasketItem(vararg basketItem: BasketItem) {
+        withContext(ioDispatcher) {
+            basketDao.insertBasketItem(*basketItem)
+        }
+    }
+
+    override suspend fun updateBasketItem(vararg basketItem: BasketItem) {
+        withContext(ioDispatcher) {
+            basketDao.updateBasketItem(*basketItem)
+        }
+    }
+}

--- a/app/src/main/java/com/example/banchan/data/source/remote/BanChanRemoteDataSource.kt
+++ b/app/src/main/java/com/example/banchan/data/source/remote/BanChanRemoteDataSource.kt
@@ -5,6 +5,7 @@ import com.example.banchan.data.response.detail.DetailResponse
 import com.example.banchan.data.response.main.MainResponse
 import com.example.banchan.data.response.side.SideResponse
 import com.example.banchan.data.response.soup.SoupResponse
+import com.example.banchan.data.source.BanChanDataSource
 import com.example.banchan.domain.model.BestModel
 import javax.inject.Inject
 

--- a/app/src/main/java/com/example/banchan/di/DataSourceModule.kt
+++ b/app/src/main/java/com/example/banchan/di/DataSourceModule.kt
@@ -1,23 +1,29 @@
 package com.example.banchan.di
 
-import com.example.banchan.data.source.remote.BanChanDataSource
+import com.example.banchan.data.source.BanChanDataSource
+import com.example.banchan.data.source.BasketDataSource
+import com.example.banchan.data.source.local.BasketLocalDataSource
 import com.example.banchan.data.source.remote.BanChanRemoteDataSource
-import com.example.banchan.data.api.BanChanApi
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object DataSourceModule {
+abstract class DataSourceModule {
 
     @Singleton
-    @Provides
-    fun provideBanChanRemoteDataSource(
-        banChanApi : BanChanApi
-    ) : BanChanDataSource {
-        return BanChanRemoteDataSource(banChanApi)
-    }
+    @Binds
+    abstract fun bindBanChanRemoteDataSource(
+        banChanRemoteDataSource: BanChanRemoteDataSource
+    ): BanChanDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindBasketLocalDataSource(
+        basketLocalDataSource: BasketLocalDataSource
+    ): BasketDataSource
 }
+

--- a/app/src/main/java/com/example/banchan/di/DatabaseModule.kt
+++ b/app/src/main/java/com/example/banchan/di/DatabaseModule.kt
@@ -1,0 +1,32 @@
+package com.example.banchan.di
+
+import android.content.Context
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import com.example.banchan.data.source.local.BanChanDatabase
+import com.example.banchan.data.source.local.BasketDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Singleton
+    @Provides
+    fun provideBanChanDatabase(@ApplicationContext context: Context): BanChanDatabase {
+        return Room.databaseBuilder(
+            context.applicationContext,
+            BanChanDatabase::class.java,
+            "banchan.db"
+        ).build()
+    }
+
+    @Singleton
+    @Provides
+    fun provideBasketDao(database: BanChanDatabase): BasketDao = database.basketDao()
+}

--- a/app/src/main/java/com/example/banchan/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/banchan/di/RepositoryModule.kt
@@ -1,23 +1,28 @@
 package com.example.banchan.di
 
-import com.example.banchan.data.repository.BanChanRepositoryImpl
-import com.example.banchan.data.source.remote.BanChanRemoteDataSource
 import com.example.banchan.data.repository.BanChanRepository
+import com.example.banchan.data.repository.BanChanRepositoryImpl
+import com.example.banchan.data.repository.BasketRepository
+import com.example.banchan.data.repository.BasketRepositoryImpl
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-class RepositoryModule {
+abstract class RepositoryModule {
 
     @Singleton
-    @Provides
-    fun provideBanChanRepository(
-        banChanDataSource: BanChanRemoteDataSource
-    ): BanChanRepository {
-        return BanChanRepositoryImpl(banChanDataSource)
-    }
+    @Binds
+    abstract fun bindBanChanRepository(
+        banChanRepositoryImpl: BanChanRepositoryImpl
+    ): BanChanRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindBasketRepository(
+        basketRepositoryImpl: BasketRepositoryImpl
+    ): BasketRepository
 }


### PR DESCRIPTION
## Summary
장바구니 DB 구현, 쿼리 추가

## Main Changes
- 장바구니 DB 구현
- 쿼리 추가
- di interface impl 경우에 provide -> bind로 수정

**insert 결과**
![image](https://user-images.githubusercontent.com/54823396/184501786-9a1184a8-f61f-44f2-83f7-4eda4a66b006.png)

**update 사용예시(insert도 동일)**
![image](https://user-images.githubusercontent.com/54823396/184501798-9178e188-3c88-4135-8451-9894b613409a.png)

**장바구니 리스트 조회결과**
![image](https://user-images.githubusercontent.com/54823396/184501803-6261abcc-cb82-48a0-8c34-3b4230e7e961.png)

Closes #29 
