### PR TITLE
[FEAT] 장바구니 담기 로직

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -34,6 +34,7 @@
         <entry key="app/src/main/res/layout/item_home_header.xml" value="0.33410672853828305" />
         <entry key="app/src/main/res/layout/item_home_loading.xml" value="0.375" />
         <entry key="app/src/main/res/layout/item_menu.xml" value="0.33" />
+        <entry key="app/src/main/res/layout/item_menu_medium.xml" value="0.12708333333333333" />
         <entry key="app/src/main/res/layout/layout_home_main_title.xml" value="0.33" />
       </map>
     </option>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,34 +4,37 @@
     <option name="filePathToZoomLevelMap">
       <map>
         <entry key="app/src/main/res/drawable/background_line.xml" value="0.1135" />
-        <entry key="app/src/main/res/drawable/background_spinner.xml" value="0.1" />
+        <entry key="app/src/main/res/drawable/bg_main_title_tv.xml" value="0.1" />
+        <entry key="app/src/main/res/drawable/ic_baseline_error_24.xml" value="0.3495" />
         <entry key="app/src/main/res/drawable/ic_cart.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/ic_check.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/ic_checkbox_checked.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/ic_checkbox_empty.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/ic_circle_cart.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/ic_circle_checkd.xml" value="0.1135" />
-        <entry key="app/src/main/res/drawable/ic_downbutton.xml" value="0.1" />
-        <entry key="app/src/main/res/drawable/ic_grid.xml" value="0.1" />
-        <entry key="app/src/main/res/drawable/item_option.xml" value="0.1" />
-        <entry key="app/src/main/res/layout/activity_main.xml" value="0.24478178368121442" />
-        <entry key="app/src/main/res/layout/fragment_home.xml" value="0.1" />
-        <entry key="app/src/main/res/layout/fragment_main_cook.xml" value="0.1" />
-        <entry key="app/src/main/res/layout/fragment_side.xml" value="0.1213768115942029" />
-        <entry key="app/src/main/res/layout/fragment_soup.xml" value="0.12952898550724637" />
+        <entry key="app/src/main/res/drawable/ic_minus.xml" value="0.1" />
+        <entry key="app/src/main/res/drawable/ic_plus.xml" value="0.1" />
+        <entry key="app/src/main/res/drawable/rounded_bottomsheet.xml" value="0.1" />
+        <entry key="app/src/main/res/drawable/rounded_dialog.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/activity_main.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/amount_counter.xml" value="0.75" />
+        <entry key="app/src/main/res/layout/appbar_ordering.xml" value="0.321875" />
+        <entry key="app/src/main/res/layout/bottomsheet_basket.xml" value="0.33" />
+        <entry key="app/src/main/res/layout/dialog_basket.xml" value="0.67" />
+        <entry key="app/src/main/res/layout/fragment_basket.xml" value="0.2807971014492754" />
+        <entry key="app/src/main/res/layout/fragment_best.xml" value="0.2" />
+        <entry key="app/src/main/res/layout/fragment_home.xml" value="0.16302083333333334" />
+        <entry key="app/src/main/res/layout/fragment_main_cook.xml" value="0.25" />
+        <entry key="app/src/main/res/layout/fragment_side.xml" value="0.16302083333333334" />
+        <entry key="app/src/main/res/layout/fragment_soup.xml" value="0.33" />
         <entry key="app/src/main/res/layout/item_banchan.xml" value="0.5686782836914064" />
-        <entry key="app/src/main/res/layout/item_home_header.xml" value="0.1" />
-        <entry key="app/src/main/res/layout/item_main_filter.xml" value="0.6353363921676858" />
-        <entry key="app/src/main/res/layout/item_main_header.xml" value="0.39651794433593757" />
-        <entry key="app/src/main/res/layout/item_medium.xml" value="0.2939702794171762" />
-        <entry key="app/src/main/res/layout/item_menu.xml" value="0.2964472946611423" />
-        <entry key="app/src/main/res/layout/item_menu_filter.xml" value="0.17142857142857143" />
-        <entry key="app/src/main/res/layout/item_menu_land.xml" value="0.25" />
-        <entry key="app/src/main/res/layout/item_menu_medium.xml" value="0.2964472946611423" />
-        <entry key="app/src/main/res/layout/item_option.xml" value="0.1272644927536232" />
-        <entry key="app/src/main/res/layout/menu_filter.xml" value="0.7116063878156137" />
-        <entry key="app/src/main/res/layout/total_filter.xml" value="0.5870674243871717" />
-        <entry key="app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/item_best_list.xml" value="0.33" />
+        <entry key="app/src/main/res/layout/item_home_empty.xml" value="0.375" />
+        <entry key="app/src/main/res/layout/item_home_error.xml" value="0.375" />
+        <entry key="app/src/main/res/layout/item_home_header.xml" value="0.33410672853828305" />
+        <entry key="app/src/main/res/layout/item_home_loading.xml" value="0.375" />
+        <entry key="app/src/main/res/layout/item_menu.xml" value="0.33" />
+        <entry key="app/src/main/res/layout/layout_home_main_title.xml" value="0.33" />
       </map>
     </option>
   </component>
@@ -40,12 +43,5 @@
   </component>
   <component name="ProjectType">
     <option name="id" value="Android" />
-  </component>
-  <component name="VisualizationToolProject">
-    <option name="state">
-      <ProjectState>
-        <option name="scale" value="0.2964472946611423" />
-      </ProjectState>
-    </option>
   </component>
 </project>

--- a/app/src/main/java/com/example/banchan/domain/model/BasketModel.kt
+++ b/app/src/main/java/com/example/banchan/domain/model/BasketModel.kt
@@ -1,0 +1,10 @@
+package com.example.banchan.domain.model
+
+data class BasketModel(
+    val detailHash : String,
+    val count : Int,
+    val isChecked : Boolean = true,
+    val name : String,
+    val price : String,
+    val image : String
+)

--- a/app/src/main/java/com/example/banchan/domain/model/ItemModel.kt
+++ b/app/src/main/java/com/example/banchan/domain/model/ItemModel.kt
@@ -8,5 +8,5 @@ data class ItemModel(
     val discountPrice: String? = null,
     val originPrice: String,
     val title: String,
-    var isCartAdded: Boolean = false
+    val isCartAdded: Boolean = false
 )

--- a/app/src/main/java/com/example/banchan/domain/model/ItemModel.kt
+++ b/app/src/main/java/com/example/banchan/domain/model/ItemModel.kt
@@ -1,9 +1,5 @@
 package com.example.banchan.domain.model
 
-import androidx.annotation.StringRes
-import com.example.banchan.R
-import com.example.banchan.presentation.adapter.main.Type
-
 data class ItemModel(
     val description: String,
     val detailHash: String,
@@ -12,5 +8,5 @@ data class ItemModel(
     val discountPrice: String? = null,
     val originPrice: String,
     val title: String,
-    val isCartAdded: Boolean = false
+    var isCartAdded: Boolean = false
 )

--- a/app/src/main/java/com/example/banchan/presentation/adapter/best/BestListAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/best/BestListAdapter.kt
@@ -9,28 +9,35 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.banchan.R
 import com.example.banchan.databinding.*
 import com.example.banchan.domain.model.BestListItem
+import com.example.banchan.domain.model.ItemModel
 import com.example.banchan.presentation.adapter.home.HomeEmptyViewHolder
 import com.example.banchan.presentation.adapter.home.HomeErrorViewHolder
 import com.example.banchan.presentation.adapter.home.HomeHeaderViewHolder
 import com.example.banchan.presentation.adapter.home.HomeLoadingViewHolder
 import com.example.banchan.presentation.adapter.menu.MenuAdapter
 
-class BestListAdapter :
+class BestListAdapter(private val basketClickListener: (ItemModel) -> Unit) :
     ListAdapter<BestListItem, RecyclerView.ViewHolder>(diffUtil) {
 
     companion object {
         val diffUtil = object : DiffUtil.ItemCallback<BestListItem>() {
             override fun areItemsTheSame(oldItem: BestListItem, newItem: BestListItem): Boolean {
                 return if (oldItem is BestListItem.BestContent && newItem is BestListItem.BestContent) {
-                    oldItem.bestItem.items == newItem.bestItem.items
+                    oldItem.bestItem.title == oldItem.bestItem.title
                 } else {
                     oldItem == newItem
                 }
             }
 
-            override fun areContentsTheSame(oldItem: BestListItem, newItem: BestListItem): Boolean =
-                oldItem == newItem
+            override fun areContentsTheSame(oldItem: BestListItem, newItem: BestListItem): Boolean {
+                return oldItem == newItem
+            }
+
+            override fun getChangePayload(oldItem: BestListItem, newItem: BestListItem): Any? {
+                return (oldItem is BestListItem.BestContent && newItem is BestListItem.BestContent)
+            }
         }
+
     }
 
     private val viewPool = RecyclerView.RecycledViewPool()
@@ -46,41 +53,17 @@ class BestListAdapter :
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder =
         when (viewType) {
-            R.layout.item_home_header -> HomeHeaderViewHolder(
-                ItemHomeHeaderBinding.inflate(
-                    LayoutInflater.from(parent.context),
-                    parent,
-                    false
-                )
-            )
+            R.layout.item_home_header -> HomeHeaderViewHolder.create(parent)
             R.layout.item_best_list -> BestContentViewHolder(
                 ItemBestListBinding.inflate(
                     LayoutInflater.from(parent.context),
                     parent,
                     false
-                ), viewPool
+                ), viewPool, basketClickListener
             )
-            R.layout.item_home_empty -> HomeEmptyViewHolder(
-                ItemHomeEmptyBinding.inflate(
-                    LayoutInflater.from(parent.context),
-                    parent,
-                    false
-                )
-            )
-            R.layout.item_home_error -> HomeErrorViewHolder(
-                ItemHomeErrorBinding.inflate(
-                    LayoutInflater.from(parent.context),
-                    parent,
-                    false
-                )
-            )
-            R.layout.item_home_loading -> HomeLoadingViewHolder(
-                ItemHomeLoadingBinding.inflate(
-                    LayoutInflater.from(parent.context),
-                    parent,
-                    false
-                )
-            )
+            R.layout.item_home_empty -> HomeEmptyViewHolder.create(parent)
+            R.layout.item_home_error -> HomeErrorViewHolder.create(parent)
+            R.layout.item_home_loading -> HomeLoadingViewHolder.create(parent)
             else -> throw UnsupportedOperationException("Unknown view")
         }
 
@@ -93,9 +76,26 @@ class BestListAdapter :
                 is BestListItem.BestLoading -> (holder as HomeLoadingViewHolder)
                 is BestListItem.BestEmpty -> (holder as HomeEmptyViewHolder)
                 is BestListItem.BestError -> (holder as HomeErrorViewHolder)
-                is BestListItem.BestContent -> (holder as BestContentViewHolder).bind(
+                is BestListItem.BestContent -> (holder as BestContentViewHolder).initBind(
                     bestListItem
                 )
+            }
+        }
+    }
+
+    override fun onBindViewHolder(
+        holder: RecyclerView.ViewHolder,
+        position: Int,
+        payloads: MutableList<Any>
+    ) {
+        if (payloads.isEmpty()) {
+            super.onBindViewHolder(holder, position, payloads)
+        } else {
+            val item = getItem(position)
+            if ((payloads[0] as Boolean) && (item is BestListItem.BestContent)) {
+                (holder as BestContentViewHolder).itemsBind(item.bestItem.items)
+            } else {
+                super.onBindViewHolder(holder, position, payloads)
             }
         }
     }
@@ -103,10 +103,11 @@ class BestListAdapter :
 
 class BestContentViewHolder(
     private val binding: ItemBestListBinding,
-    private val pool: RecyclerView.RecycledViewPool
+    private val pool: RecyclerView.RecycledViewPool,
+    private val basketClickListener: (ItemModel) -> Unit
 ) : RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(bestModel: BestListItem.BestContent) {
+    fun initBind(bestModel: BestListItem.BestContent) {
         binding.title = bestModel.bestItem.title
         binding.rvBestList.setRecycledViewPool(pool)
 
@@ -116,8 +117,14 @@ class BestContentViewHolder(
             }
         binding.rvBestList.layoutManager = layoutManager
 
-        val menuAdapter = MenuAdapter()
+        val menuAdapter = MenuAdapter(basketClickListener)
         binding.rvBestList.adapter = menuAdapter
         menuAdapter.submitList(bestModel.bestItem.items)
     }
+
+    fun itemsBind(items: List<ItemModel>) {
+        val menuAdapter = binding.rvBestList.adapter as MenuAdapter
+        menuAdapter.submitList(items)
+    }
+
 }

--- a/app/src/main/java/com/example/banchan/presentation/adapter/home/CommonAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/home/CommonAdapter.kt
@@ -9,7 +9,10 @@ import com.example.banchan.domain.model.ItemModel
 import com.example.banchan.presentation.adapter.main.MediumMenuViewHolder
 import com.example.banchan.presentation.home.maincook.Filter
 
-class CommonAdapter(private val onFilterChanged: (Filter) -> Unit) :
+class CommonAdapter(
+    private val onFilterChanged: (Filter) -> Unit,
+    private val basketClickListener: (ItemModel) -> Unit
+) :
     ListAdapter<CommonItemListModel, RecyclerView.ViewHolder>(DiffCallback()) {
     override fun getItemViewType(position: Int): Int {
         return when (getItem(position)) {
@@ -60,10 +63,27 @@ class CommonAdapter(private val onFilterChanged: (Filter) -> Unit) :
                     onFilterChanged
                 )
             is CommonItemListModel.SmallItem -> {
-                (holder as MediumMenuViewHolder).bind(item.item) {}
+                (holder as MediumMenuViewHolder).bind(item.item, basketClickListener)
             }
             else -> {
 
+            }
+        }
+    }
+
+    override fun onBindViewHolder(
+        holder: RecyclerView.ViewHolder,
+        position: Int,
+        payloads: MutableList<Any>
+    ) {
+        if(payloads.isEmpty()) {
+            super.onBindViewHolder(holder, position, payloads)
+        } else {
+            val commonListItem = getItem(position)
+            if (payloads[0] as Boolean && commonListItem is CommonItemListModel.SmallItem) {
+                (holder as MediumMenuViewHolder).setItem(commonListItem.item)
+            } else {
+                super.onBindViewHolder(holder, position, payloads)
             }
         }
     }
@@ -92,6 +112,18 @@ class CommonAdapter(private val onFilterChanged: (Filter) -> Unit) :
                 newItem: CommonItemListModel
             ): Boolean {
                 return oldItem == newItem
+            }
+
+            override fun getChangePayload(
+                oldItem: CommonItemListModel,
+                newItem: CommonItemListModel
+            ): Any? {
+                return if (oldItem is CommonItemListModel.SmallItem && newItem is CommonItemListModel.SmallItem) {
+                    if (oldItem.item.isCartAdded != newItem.item.isCartAdded) true
+                    else null
+                } else {
+                    null
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/banchan/presentation/adapter/main/LargeMenuViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/main/LargeMenuViewHolder.kt
@@ -8,9 +8,14 @@ import com.example.banchan.domain.model.ItemModel
 
 class LargeMenuViewHolder(private val binding: ItemMenuLargeBinding) :
     RecyclerView.ViewHolder(binding.root) {
-    fun bind(item: ItemModel, onClick: (String) -> Unit) {
+    fun bind(item: ItemModel, cartClick: (ItemModel) -> Unit) {
         binding.item = item
-        binding.ivCart.setOnClickListener { onClick(item.detailHash) }
+        binding.ivCart.setOnClickListener { cartClick(item) }
+        binding.executePendingBindings()
+    }
+
+    fun setItem(item: ItemModel) {
+        binding.item = item
         binding.executePendingBindings()
     }
 

--- a/app/src/main/java/com/example/banchan/presentation/adapter/main/MediumMenuViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/main/MediumMenuViewHolder.kt
@@ -8,9 +8,15 @@ import com.example.banchan.domain.model.ItemModel
 
 class MediumMenuViewHolder(private val binding: ItemMenuMediumBinding) :
     RecyclerView.ViewHolder(binding.root) {
-    fun bind(item: ItemModel, onClick: (String) -> Unit) {
+
+    fun bind(item: ItemModel, cartClick: (ItemModel) -> Unit) {
         binding.item = item
-        binding.ivCart.setOnClickListener { onClick(item.detailHash) }
+        binding.ivCart.setOnClickListener { cartClick(item) }
+        binding.executePendingBindings()
+    }
+
+    fun setItem(item: ItemModel) {
+        binding.item = item
         binding.executePendingBindings()
     }
 

--- a/app/src/main/java/com/example/banchan/presentation/adapter/menu/MenuAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/menu/MenuAdapter.kt
@@ -7,7 +7,25 @@ import androidx.recyclerview.widget.ListAdapter
 import com.example.banchan.domain.model.ItemModel
 import com.example.banchan.databinding.ItemMenuBinding
 
-class MenuAdapter : ListAdapter<ItemModel, MenuViewHolder>(DiffCallback()) {
+class MenuAdapter(private val basketClickListener: (ItemModel) -> Unit) :
+    ListAdapter<ItemModel, MenuViewHolder>(DiffCallback()) {
+
+    companion object {
+        class DiffCallback : DiffUtil.ItemCallback<ItemModel>() {
+            override fun areItemsTheSame(oldItem: ItemModel, newItem: ItemModel): Boolean {
+                return oldItem.detailHash == newItem.detailHash
+            }
+
+            override fun areContentsTheSame(oldItem: ItemModel, newItem: ItemModel): Boolean {
+                return oldItem == newItem
+            }
+
+            override fun getChangePayload(oldItem: ItemModel, newItem: ItemModel): Any? {
+                return oldItem.isCartAdded != newItem.isCartAdded
+            }
+        }
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MenuViewHolder {
         return MenuViewHolder(
             ItemMenuBinding.inflate(
@@ -19,18 +37,23 @@ class MenuAdapter : ListAdapter<ItemModel, MenuViewHolder>(DiffCallback()) {
     }
 
     override fun onBindViewHolder(holder: MenuViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(getItem(position), basketClickListener)
     }
 
-    companion object {
-        class DiffCallback : DiffUtil.ItemCallback<ItemModel>() {
-            override fun areContentsTheSame(oldItem: ItemModel, newItem: ItemModel): Boolean {
-                return oldItem.detailHash == newItem.detailHash
-            }
-
-            override fun areItemsTheSame(oldItem: ItemModel, newItem: ItemModel): Boolean {
-                return oldItem == newItem
+    override fun onBindViewHolder(
+        holder: MenuViewHolder,
+        position: Int,
+        payloads: MutableList<Any>
+    ) {
+        if(payloads.isEmpty()) {
+            super.onBindViewHolder(holder, position, payloads)
+        } else {
+            if (payloads[0] as Boolean) {
+                holder.setItem(getItem(position))
+            } else {
+                super.onBindViewHolder(holder, position, payloads)
             }
         }
     }
+
 }

--- a/app/src/main/java/com/example/banchan/presentation/adapter/menu/MenuViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/menu/MenuViewHolder.kt
@@ -6,7 +6,14 @@ import com.example.banchan.databinding.ItemMenuBinding
 
 class MenuViewHolder(private val binding: ItemMenuBinding) :
     RecyclerView.ViewHolder(binding.root) {
-    fun bind(item: ItemModel) {
+
+    fun bind(item: ItemModel, basketClickListener: (ItemModel) -> Unit) {
         binding.item = item
+        binding.ivMenuBasket.setOnClickListener{ basketClickListener.invoke(item) }
+    }
+
+    fun setItem(item: ItemModel) {
+        binding.item = item
+        binding.executePendingBindings()
     }
 }

--- a/app/src/main/java/com/example/banchan/presentation/basket/BasketFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/basket/BasketFragment.kt
@@ -1,0 +1,60 @@
+package com.example.banchan.presentation.basket
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.example.banchan.R
+
+// TODO: Rename parameter arguments, choose names that match
+// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+private const val ARG_PARAM1 = "param1"
+private const val ARG_PARAM2 = "param2"
+
+/**
+ * A simple [Fragment] subclass.
+ * Use the [BasketFragment.newInstance] factory method to
+ * create an instance of this fragment.
+ */
+class BasketFragment : Fragment() {
+    // TODO: Rename and change types of parameters
+    private var param1: String? = null
+    private var param2: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            param1 = it.getString(ARG_PARAM1)
+            param2 = it.getString(ARG_PARAM2)
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_basket, container, false)
+    }
+
+    companion object {
+        /**
+         * Use this factory method to create a new instance of
+         * this fragment using the provided parameters.
+         *
+         * @param param1 Parameter 1.
+         * @param param2 Parameter 2.
+         * @return A new instance of fragment BasketFragment.
+         */
+        // TODO: Rename and change types and number of parameters
+        @JvmStatic
+        fun newInstance(param1: String, param2: String) =
+            BasketFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_PARAM1, param1)
+                    putString(ARG_PARAM2, param2)
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/custom/AmountCounter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/custom/AmountCounter.kt
@@ -1,0 +1,49 @@
+package com.example.banchan.presentation.custom
+
+import android.content.Context
+import android.content.res.TypedArray
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.withStyledAttributes
+import com.example.banchan.R
+import com.example.banchan.databinding.AmountCounterBinding
+
+class AmountCounter(
+    context: Context,
+    attrs: AttributeSet?
+) : ConstraintLayout(context, attrs) {
+
+    private val binding: AmountCounterBinding by lazy {
+        AmountCounterBinding.inflate(
+            LayoutInflater.from(context),
+            this,
+            false
+        )
+    }
+
+    init {
+        context.withStyledAttributes(attrs, R.styleable.AmountCounter) {
+            setTypeArray(this)
+        }
+        addView(binding.root)
+    }
+
+    private fun setTypeArray(typedArray: TypedArray) {
+        setAmount(typedArray.getInteger(R.styleable.AmountCounter_amount, 1))
+    }
+
+    fun setAmount(amount: Int) {
+        if (amount < 1) binding.amount = 1
+        else if (amount > 99) binding.amount = 99
+        else binding.amount = amount
+    }
+
+    fun setOnMinusClickListener(listener: OnClickListener) {
+        binding.fabMinus.setOnClickListener(listener)
+    }
+
+    fun setOnPlusClickListener(listener: OnClickListener) {
+        binding.fabPlus.setOnClickListener(listener)
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/dialog/BasketBottomSheet.kt
+++ b/app/src/main/java/com/example/banchan/presentation/dialog/BasketBottomSheet.kt
@@ -1,0 +1,76 @@
+package com.example.banchan.presentation.dialog
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
+import com.example.banchan.databinding.BottomsheetBasketBinding
+import com.example.banchan.domain.model.BasketModel
+import com.example.banchan.presentation.main.BasketViewModel
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+class BasketBottomSheet : BottomSheetDialogFragment() {
+
+    companion object {
+        const val TAG = "BasketBottomSheet"
+    }
+
+    private val basketViewModel: BasketViewModel by activityViewModels()
+
+    private var _binding: BottomsheetBasketBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = BottomsheetBasketBinding.inflate(layoutInflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initBottomSheet()
+    }
+
+    private fun initBottomSheet() {
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.vm = basketViewModel
+        binding.tvBasketCancel.setOnClickListener {
+            this.dismiss()
+        }
+        binding.btnBasketAdd.setOnClickListener {
+            //TODO : 장바구니 DB에 저장하는 로직
+            with(basketViewModel) {
+                addBasketList(
+                    BasketModel(
+                        count = selectedBasketCount.value!!,
+                        image = selectedBasketItem.value!!.image,
+                        price = selectedBasketItem.value!!.originPrice,
+                        name = selectedBasketItem.value!!.title,
+                        detailHash = selectedBasketItem.value!!.detailHash
+                    )
+                )
+            }
+            this.dismiss()
+            showDialog()
+        }
+    }
+
+    private fun showDialog() {
+        val targetDialog = parentFragmentManager.findFragmentByTag(BasketCheckDialog.TAG)
+        if (targetDialog == null) {
+            val checkDialog = BasketCheckDialog()
+            checkDialog.isCancelable = false
+            checkDialog.show(parentFragmentManager, BasketCheckDialog.TAG)
+        }
+    }
+
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/dialog/BasketCheckDialog.kt
+++ b/app/src/main/java/com/example/banchan/presentation/dialog/BasketCheckDialog.kt
@@ -1,0 +1,57 @@
+package com.example.banchan.presentation.dialog
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import com.example.banchan.databinding.DialogBasketBinding
+import com.example.banchan.presentation.main.FragmentType
+import com.example.banchan.presentation.main.MainViewModel
+
+class BasketCheckDialog : DialogFragment() {
+
+    companion object {
+        const val TAG = "BasketCheckDialog"
+    }
+
+    private var _binding: DialogBasketBinding? = null
+    private val binding get() = _binding!!
+
+    private val mainViewModel: MainViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = DialogBasketBinding.inflate(layoutInflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        initDialog()
+    }
+
+    private fun initDialog() {
+        with(binding) {
+            tvDialogBasketContinue.setOnClickListener {
+                this@BasketCheckDialog.dismiss()
+            }
+            tvDialogBasketCheck.setOnClickListener {
+                this@BasketCheckDialog.dismiss()
+                mainViewModel.setCurrentFragment(FragmentType.Basket)
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/HomeFragment.kt
@@ -1,21 +1,36 @@
 package com.example.banchan.presentation.home
 
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentHomeBinding
 import com.example.banchan.presentation.base.BaseFragment
 import com.example.banchan.presentation.adapter.home.HomeViewPagerAdapter
+import com.example.banchan.presentation.main.BasketViewModel
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
+
+    private val basketViewModel: BasketViewModel by activityViewModels()
 
     override fun initViews() {
         initViewPager()
     }
 
     override fun observe() {
-
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                basketViewModel.basketList.collectLatest {
+                    binding.abHome.setCartCount(it.size)
+                }
+            }
+        }
     }
 
     private fun initViewPager() {

--- a/app/src/main/java/com/example/banchan/presentation/home/HomeTabFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/HomeTabFragment.kt
@@ -1,0 +1,40 @@
+package com.example.banchan.presentation.home
+
+import androidx.annotation.LayoutRes
+import androidx.databinding.ViewDataBinding
+import androidx.fragment.app.activityViewModels
+import com.example.banchan.domain.model.ItemModel
+import com.example.banchan.presentation.base.BaseFragment
+import com.example.banchan.presentation.dialog.BasketBottomSheet
+import com.example.banchan.presentation.main.BasketViewModel
+import com.example.banchan.presentation.main.FragmentType
+import com.example.banchan.presentation.main.MainViewModel
+
+abstract class HomeTabFragment<DB : ViewDataBinding>(@LayoutRes val layout: Int) :
+    BaseFragment<DB>(layout) {
+
+    protected val mainViewModel: MainViewModel by activityViewModels()
+    protected val basketViewModel: BasketViewModel by activityViewModels()
+
+    private val detailClickListener: ((String)->Unit) = {
+
+    }
+
+    protected val basketIconClickListener: ((ItemModel)->Unit) = { itemModel ->
+        if (itemModel.isCartAdded) {
+            mainViewModel.setCurrentFragment(FragmentType.Basket)
+        } else {
+            basketViewModel.setSelectedBasketItem(itemModel)
+            showBottomSheet()
+        }
+    }
+
+    protected fun showBottomSheet() {
+        val targetBottomSheet = parentFragmentManager.findFragmentByTag(BasketBottomSheet.TAG)
+        if (targetBottomSheet == null) {
+            val bottomSheet = BasketBottomSheet()
+            bottomSheet.show(parentFragmentManager, BasketBottomSheet.TAG)
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/banchan/presentation/home/side/SideFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/side/SideFragment.kt
@@ -7,20 +7,24 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentSoupBinding
-import com.example.banchan.presentation.base.BaseFragment
-import com.example.banchan.presentation.adapter.main.GridSpacingItemDecorator
 import com.example.banchan.presentation.adapter.home.CommonAdapter
+import com.example.banchan.presentation.adapter.home.CommonItemListModel
+import com.example.banchan.presentation.adapter.main.GridSpacingItemDecorator
+import com.example.banchan.presentation.home.HomeTabFragment
 import com.example.banchan.util.dimen.dpToPx
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class SideFragment : BaseFragment<FragmentSoupBinding>(R.layout.fragment_soup) {
+class SideFragment : HomeTabFragment<FragmentSoupBinding>(R.layout.fragment_soup) {
     private val viewModel by viewModels<SideViewModel>()
     private val sideAdapter by lazy {
-        CommonAdapter {
-            viewModel.changeFilter(it)
-        }
+        CommonAdapter(
+            { viewModel.changeFilter(it) },
+            basketIconClickListener
+        )
     }
 
     override fun initViews() {
@@ -44,7 +48,19 @@ class SideFragment : BaseFragment<FragmentSoupBinding>(R.layout.fragment_soup) {
     override fun observe() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.dishes.collect {
+                viewModel.dishes.combine(basketViewModel.basketList) { dishes, basketList ->
+                    dishes.map { dish ->
+                        if (dish is CommonItemListModel.SmallItem) {
+                            dish.copy(
+                                item = dish.item.copy(
+                                    isCartAdded = dish.item.detailHash in basketList.map { it.detailHash }
+                                )
+                            )
+                        } else {
+                            dish
+                        }
+                    }
+                }.collectLatest {
                     sideAdapter.submitList(it)
                 }
             }

--- a/app/src/main/java/com/example/banchan/presentation/main/BasketViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/main/BasketViewModel.kt
@@ -1,0 +1,48 @@
+package com.example.banchan.presentation.main
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.example.banchan.domain.model.BasketModel
+import com.example.banchan.domain.model.ItemModel
+import com.example.banchan.util.ext.toNum
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class BasketViewModel : ViewModel() {
+
+    private val _selectedBasketItem = MutableLiveData<ItemModel>(null)
+    val selectedBasketItem: LiveData<ItemModel> = _selectedBasketItem
+    private val _selectedBasketCount = MutableLiveData<Int>(1)
+    val selectedBasketCount: LiveData<Int> = _selectedBasketCount
+
+    private val _basketList = MutableStateFlow<List<BasketModel>>(listOf())
+    val basketList: StateFlow<List<BasketModel>> = _basketList
+
+    fun setSelectedBasketItem(basketItem : ItemModel) {
+        _selectedBasketItem.value = basketItem
+        _selectedBasketCount.value = 1
+    }
+
+    fun basketCountDecrease() {
+        _selectedBasketCount.value = _selectedBasketCount.value!!.dec()
+    }
+
+    fun basketCountIncrease() {
+        _selectedBasketCount.value = _selectedBasketCount.value!!.inc()
+    }
+
+    fun getAmountSum(count : Int) : Int {
+        return if (_selectedBasketItem.value!!.discountPercent == null) {
+            (_selectedBasketItem.value!!.originPrice.toNum()!! * count)
+        } else {
+            (_selectedBasketItem.value!!.discountPrice.toNum()!! * count)
+        }
+    }
+
+    fun addBasketList(basketModel : BasketModel) {
+        val list = _basketList.value + basketModel
+        _basketList.value = list
+    }
+
+}

--- a/app/src/main/java/com/example/banchan/presentation/main/FragmentType.kt
+++ b/app/src/main/java/com/example/banchan/presentation/main/FragmentType.kt
@@ -2,7 +2,7 @@ package com.example.banchan.presentation.main
 
 enum class FragmentType(val tag: String) {
     Home("home"),
-    Cart("cart"),
+    Basket("basket"),
     ProductDetail("product_detail"),
     OrderDetail("order_detail"),
     RecentlyViewedProduct("recently_viewed_product")

--- a/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
@@ -10,7 +10,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.example.banchan.R
 import com.example.banchan.databinding.ActivityMainBinding
 import com.example.banchan.presentation.basket.BasketFragment
-import com.example.banchan.presentation.detail.DetailFragment
+import com.example.banchan.presentation.productdetail.ProductDetailFragment
 import com.example.banchan.presentation.home.HomeFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -39,8 +39,8 @@ class MainActivity : AppCompatActivity() {
                         val fragment = when (it) {
                             FragmentType.Home -> HomeFragment()
                             FragmentType.Basket -> BasketFragment()
-                            FragmentType.OrderDetail -> DetailFragment()
-                            FragmentType.ProductDetail -> HomeFragment()
+                            FragmentType.OrderDetail -> HomeFragment()
+                            FragmentType.ProductDetail -> ProductDetailFragment()
                             FragmentType.RecentlyViewedProduct -> HomeFragment()
                         }
                         supportFragmentManager.commit {

--- a/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
@@ -9,6 +9,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.example.banchan.R
 import com.example.banchan.databinding.ActivityMainBinding
+import com.example.banchan.presentation.basket.BasketFragment
+import com.example.banchan.presentation.detail.DetailFragment
 import com.example.banchan.presentation.home.HomeFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -31,22 +33,35 @@ class MainActivity : AppCompatActivity() {
         this.lifecycleScope.launch {
             this@MainActivity.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 mainViewModel.currentFragment.collectLatest {
-                    // 추후 다른 Fragment 생성 후 수정 예정
-                    val fragment = when(it) {
-                        FragmentType.Home -> HomeFragment()
-                        FragmentType.Cart -> HomeFragment()
-                        FragmentType.OrderDetail -> HomeFragment()
-                        FragmentType.ProductDetail -> HomeFragment()
-                        FragmentType.RecentlyViewedProduct -> HomeFragment()
-                    }
-                    supportFragmentManager.commit {
-                        setReorderingAllowed(true)
-                        if(it != FragmentType.Home) addToBackStack(it.tag)
-                        replace(R.id.layout_main_container, fragment, it.tag)
+                    val targetFragment = supportFragmentManager.findFragmentByTag(it.tag)
+                    if (targetFragment == null) {
+                        // 추후 다른 Fragment 생성 후 수정 예정
+                        val fragment = when (it) {
+                            FragmentType.Home -> HomeFragment()
+                            FragmentType.Basket -> BasketFragment()
+                            FragmentType.OrderDetail -> DetailFragment()
+                            FragmentType.ProductDetail -> HomeFragment()
+                            FragmentType.RecentlyViewedProduct -> HomeFragment()
+                        }
+                        supportFragmentManager.commit {
+                            setReorderingAllowed(true)
+                            if (it != FragmentType.Home) addToBackStack(it.tag)
+                            replace(R.id.layout_main_container, fragment, it.tag)
+                        }
                     }
                 }
             }
         }
     }
 
+    override fun onBackPressed() {
+        super.onBackPressed()
+        when(supportFragmentManager.findFragmentById(R.id.layout_main_container)?.tag) {
+            FragmentType.Home.tag -> mainViewModel.setCurrentFragment(FragmentType.Home)
+            FragmentType.Basket.tag -> mainViewModel.setCurrentFragment(FragmentType.Basket)
+            FragmentType.OrderDetail.tag -> mainViewModel.setCurrentFragment(FragmentType.OrderDetail)
+            FragmentType.ProductDetail.tag -> mainViewModel.setCurrentFragment(FragmentType.ProductDetail)
+            FragmentType.RecentlyViewedProduct.tag -> mainViewModel.setCurrentFragment(FragmentType.RecentlyViewedProduct)
+        }
+    }
 }

--- a/app/src/main/java/com/example/banchan/presentation/productdetail/ProductDetailFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/productdetail/ProductDetailFragment.kt
@@ -1,0 +1,22 @@
+package com.example.banchan.presentation.productdetail
+
+import android.util.Log
+import androidx.fragment.app.activityViewModels
+import com.example.banchan.R
+import com.example.banchan.databinding.FragmentProductDetailBinding
+import com.example.banchan.presentation.base.BaseFragment
+import com.example.banchan.presentation.main.MainViewModel
+
+class ProductDetailFragment : BaseFragment<FragmentProductDetailBinding>(R.layout.fragment_product_detail) {
+
+    private val mainViewModel: MainViewModel by activityViewModels()
+
+    override fun observe() {
+        Log.d("DetailFragment","observe")
+    }
+
+    override fun initViews() {
+        Log.d("DetailFragment","initViews")
+    }
+
+}

--- a/app/src/main/java/com/example/banchan/util/ext/AmountCounterBindingAdapter.kt
+++ b/app/src/main/java/com/example/banchan/util/ext/AmountCounterBindingAdapter.kt
@@ -1,0 +1,20 @@
+package com.example.banchan.util.ext
+
+import android.view.View
+import androidx.databinding.BindingAdapter
+import com.example.banchan.presentation.custom.AmountCounter
+
+@BindingAdapter("app:amount")
+fun AmountCounter.amount(amount: Int) {
+    this.setAmount(amount)
+}
+
+@BindingAdapter("app:onMinusClick")
+fun AmountCounter.onMinusClick(listener: View.OnClickListener) {
+    this.setOnMinusClickListener(listener)
+}
+
+@BindingAdapter("app:onPlusClick")
+fun AmountCounter.onPlusClick(listener: View.OnClickListener) {
+    this.setOnPlusClickListener(listener)
+}

--- a/app/src/main/res/drawable/ic_minus.xml
+++ b/app/src/main/res/drawable/ic_minus.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M5,12H19"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_plus.xml
+++ b/app/src/main/res/drawable/ic_plus.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,5V19"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M5,12H19"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/rounded_bottomsheet.xml
+++ b/app/src/main/res/drawable/rounded_bottomsheet.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/white" />
+
+    <corners
+        android:topLeftRadius="20dp"
+        android:topRightRadius="20dp" />
+
+</shape>

--- a/app/src/main/res/drawable/rounded_dialog.xml
+++ b/app/src/main/res/drawable/rounded_dialog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@android:color/white" />
+    <corners android:radius="14dp" />
+
+</shape>

--- a/app/src/main/res/layout/amount_counter.xml
+++ b/app/src/main/res/layout/amount_counter.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="amount"
+            type="Integer" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/amount_counter"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_minus"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:alpha="@{amount &lt;= 1 ? 0.7f : 1.0f}"
+            android:backgroundTint="@color/white"
+            android:enabled="@{amount &lt;= 1 ? false : true}"
+            app:elevation="2dp"
+            app:fabCustomSize="44dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_minus" />
+
+        <TextView
+            android:id="@+id/tv_amount"
+            android:layout_width="44dp"
+            android:layout_height="0dp"
+            android:gravity="center"
+            android:text="@{amount.toString()}"
+            android:textSize="18sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/fab_plus"
+            app:layout_constraintStart_toEndOf="@id/fab_minus"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="1" />
+
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_plus"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:alpha="@{amount >= 99 ? 0.7f : 1.0f}"
+            android:backgroundTint="@color/white"
+            android:enabled="@{amount >= 99 ? false : true}"
+            app:elevation="2dp"
+            app:fabCustomSize="44dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_amount"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_plus" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/bottomsheet_basket.xml
+++ b/app/src/main/res/layout/bottomsheet_basket.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <import type="android.view.View" />
+
+        <variable
+            name="vm"
+            type="com.example.banchan.presentation.main.BasketViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="275dp">
+
+        <TextView
+            android:id="@+id/tv_basket_title"
+            style="@style/tv_normal_14.Black"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/bottom_sheet_basket_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_basket_cancel"
+            style="@style/tv_normal_14.Black"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:text="@string/bottom_sheet_basket_cancel"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/iv_basket_dish"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="59dp"
+            imageUrl="@{vm.selectedBasketItem.image}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="ContentDescription" />
+
+        <TextView
+            android:id="@+id/tv_basket_dish_title"
+            style="@style/tv_bold_14"
+            android:layout_width="0dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="6dp"
+            android:layout_marginEnd="16dp"
+            android:gravity="center_vertical"
+            android:text="@{vm.selectedBasketItem.title}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/iv_basket_dish"
+            app:layout_constraintTop_toTopOf="@id/iv_basket_dish"
+            tools:text="새콤달콤 오징어무침" />
+
+        <TextView
+            android:id="@+id/tv_basket_discount"
+            style="@style/tv_normal_14.Sale"
+            android:layout_width="wrap_content"
+            android:layout_height="24dp"
+            android:gravity="center_vertical"
+            android:text="@{vm.selectedBasketItem.discountPercent}"
+            android:visibility="@{vm.selectedBasketItem.discountPercent == null ? View.GONE : View.VISIBLE}"
+            app:layout_constraintStart_toStartOf="@id/tv_basket_dish_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_basket_dish_title"
+            tools:text="20%" />
+
+        <TextView
+            android:id="@+id/tv_basket_display_price"
+            style="@style/tv_bold_14"
+            android:layout_width="wrap_content"
+            android:layout_height="24dp"
+            android:layout_marginStart="4dp"
+            android:gravity="center_vertical"
+            android:text="@{vm.selectedBasketItem.discountPercent == null ? vm.selectedBasketItem.originPrice : vm.selectedBasketItem.discountPrice}"
+            app:layout_constraintStart_toEndOf="@id/tv_basket_discount"
+            app:layout_constraintTop_toTopOf="@id/tv_basket_discount"
+            tools:text="6,000원" />
+
+        <TextView
+            android:id="@+id/tv_basket_origin_price"
+            style="@style/tv_normal_12.GreyDefault"
+            android:layout_width="wrap_content"
+            android:layout_height="24dp"
+            android:layout_marginStart="4dp"
+            android:background="@drawable/background_line"
+            android:gravity="center_vertical"
+            android:text="@{vm.selectedBasketItem.originPrice}"
+            android:visibility="@{vm.selectedBasketItem.discountPercent == null ? View.GONE : View.VISIBLE}"
+            app:layout_constraintStart_toEndOf="@id/tv_basket_display_price"
+            app:layout_constraintTop_toTopOf="@id/tv_basket_discount"
+            tools:text="7,500원" />
+
+        <TextView
+            android:id="@+id/tv_basket_price_sum"
+            style="@style/tv_bold_14"
+            android:layout_width="0dp"
+            android:layout_height="24dp"
+            android:gravity="center_vertical"
+            android:text="@{@string/bottom_sheet_sum_amount(vm.getAmountSum(vm.selectedBasketCount))}"
+            app:layout_constraintEnd_toStartOf="@+id/amount_counter"
+            app:layout_constraintStart_toStartOf="@id/iv_basket_dish"
+            app:layout_constraintTop_toTopOf="@id/amount_counter"
+            app:layout_constraintBottom_toBottomOf="@id/amount_counter"
+            tools:text="6,000원" />
+
+        <com.example.banchan.presentation.custom.AmountCounter
+            android:id="@+id/amount_counter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            app:onMinusClick="@{()->vm.basketCountDecrease()}"
+            app:onPlusClick="@{()->vm.basketCountIncrease()}"
+            app:amount="@{vm.selectedBasketCount}"
+            app:layout_constraintTop_toBottomOf="@id/iv_basket_dish"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <Button
+            android:id="@+id/btn_basket_add"
+            style="@style/common_button_style"
+            android:layout_marginBottom="16dp"
+            android:layout_marginTop="24dp"
+            android:text="@{@string/bottom_sheet_basket_count(vm.selectedBasketCount)}"
+            app:layout_constraintTop_toBottomOf="@id/amount_counter"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:text="1개 담기" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/dialog_basket.xml
+++ b/app/src/main/res/layout/dialog_basket.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="312dp"
+    android:layout_height="wrap_content"
+    android:background="@drawable/rounded_dialog">
+
+    <TextView
+        android:id="@+id/tv_dialog_basket_comment"
+        android:layout_width="264dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="24dp"
+        android:text="@string/dialog_basket_comment"
+        android:gravity="left"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <TextView
+        android:id="@+id/tv_dialog_basket_continue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="24dp"
+        android:layout_marginBottom="24dp"
+        android:layout_marginTop="32dp"
+        android:text="@string/dialog_basket_continue"
+        android:textColor="@color/primary_accent"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tv_dialog_basket_comment" />
+
+    <TextView
+        android:id="@+id/tv_dialog_basket_check"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="24dp"
+        android:text="@string/dialog_basket_check"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/tv_dialog_basket_continue"
+        app:layout_constraintEnd_toStartOf="@id/tv_dialog_basket_continue" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_basket.xml
+++ b/app/src/main/res/layout/fragment_basket.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.basket.BasketFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/hello_blank_fragment" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_product_detail.xml
+++ b/app/src/main/res/layout/fragment_product_detail.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.productdetail.ProductDetailFragment">
+
+        <com.example.banchan.presentation.custom.OrderingAppBar
+            android:id="@+id/ab_detail"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            app:layout_constraintTop_toTopOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_menu.xml
+++ b/app/src/main/res/layout/item_menu.xml
@@ -28,6 +28,7 @@
             tools:src="@tools:sample/avatars" />
 
         <ImageView
+            android:id="@+id/iv_menu_basket"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -4,4 +4,8 @@
         <attr name="cartCount" format="integer" />
         <attr name="isShipping" format="boolean" />
     </declare-styleable>
+
+    <declare-styleable name="AmountCounter">
+        <attr name="amount" format="integer" />
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,11 +15,23 @@
 
     <string name="total_format">총 %d개 상품</string>
 
+    <string name="bottom_sheet_basket_title">장바구니 담기</string>
+    <string name="bottom_sheet_basket_cancel">취소</string>
+    <string name="bottom_sheet_sum_amount">%,d원</string>
+    <string name="bottom_sheet_basket_count">%d개 담기</string>
+
+    <string name="dialog_basket_comment">선택한 상품이 장바구니에 담겼습니다.</string>
+    <string name="dialog_basket_check">장바구니 확인</string>
+    <string name="dialog_basket_continue">계속 쇼핑하기</string>
+
     <string-array name="home_tab_title_array">
         <item>기획전</item>
         <item>든든한 메인요리</item>
         <item>뜨끈한 국물요리</item>
         <item>정갈한 밑반찬</item>
     </string-array>
+
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,7 +20,6 @@
         <item name="android:textStyle">bold</item>
     </style>
 
-
     <style name="home_tab_layout" parent="Widget.MaterialComponents.TabLayout">
         <item name="tabBackground">@drawable/bg_home_tab</item>
         <item name="tabMode">scrollable</item>
@@ -31,6 +30,17 @@
         <item name="tabPaddingTop">8dp</item>
         <item name="tabPaddingBottom">10dp</item>
         <item name="tabTextAppearance">@style/tv_bold_14</item>
+    </style>
+
+    <style name="common_button_style" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="backgroundTint">@color/primary_main</item>
+        <item name="android:layout_height">56dp</item>
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_marginStart">16dp</item>
+        <item name="android:layout_marginEnd">16dp</item>
+        <item name="android:inset">16dp</item>
+        <item name="android:textSize">18sp</item>
+        <item name="android:textColor">@color/white</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,13 +6,14 @@
         <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/primary_main</item>
+        <item name="colorSecondary">#FFFFFF</item>
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor">@color/primary_main</item>
         <item name="android:textColor">@color/black</item>
         <!-- Customize your theme here. -->
+        <item name="bottomSheetDialogTheme">@style/AppBottomSheetDialogTheme</item>
     </style>
 
     <style name="tv_normal_14" parent="TextAppearance.AppCompat">
@@ -37,5 +38,14 @@
         <item name="android:textColor">@color/greyscale_default</item>
     </style>
 
+    <style name="AppBottomSheetDialogTheme"
+        parent="Theme.Design.Light.BottomSheetDialog">
+        <item name="bottomSheetStyle">@style/AppModalStyle</item>
+        <item name="android:windowIsFloating">false</item>
+    </style>
+
+    <style name="AppModalStyle" parent="Widget.Design.BottomSheet.Modal">
+        <item name="android:background">@drawable/rounded_bottomsheet</item>
+    </style>
 
 </resources>


### PR DESCRIPTION
## Summary
- 홈화면에서 장바구니 아이콘 클릭시 진행되는 로직을 구현합니다.
- 장바구니 아이콘인 경우 장바구니 담기 로직을 진행하고, 체크 아이콘인 경우 장바구니 화면으로 이동합니다.

## Main Changes
- [x] 장바구니 담기 BottomSheet 구현
- [x] 수량 카운트 CustomView 구현 (다른 화면에서도 사용)
- [x] 장바구니 확인 Dialog 구현
- [x] 기획전 탭 장바구니 클릭 로직
- [x] 메인 요리 탭 장바구니 장바구니 클릭 로직
- [x] 국물 요리 / 사이드 요리 장바구니 클릭 로직

Closes #17
