### PR TITLE
[FEAT] 내역 DB 구현, datasource, repository 구현 #37

### DIFF
--- a/app/src/main/java/com/example/banchan/data/repository/HistoryRepository.kt
+++ b/app/src/main/java/com/example/banchan/data/repository/HistoryRepository.kt
@@ -1,0 +1,10 @@
+package com.example.banchan.data.repository
+
+import com.example.banchan.data.source.local.history.History
+import com.example.banchan.data.source.local.history.HistoryItem
+import kotlinx.coroutines.flow.Flow
+
+interface HistoryRepository {
+    fun getHistoryWithItems(): Flow<Map<History, List<HistoryItem>>>
+    suspend fun insertHistoryWithItems(items: List<HistoryItem>)
+}

--- a/app/src/main/java/com/example/banchan/data/repository/HistoryRepository.kt
+++ b/app/src/main/java/com/example/banchan/data/repository/HistoryRepository.kt
@@ -5,6 +5,6 @@ import com.example.banchan.data.source.local.history.HistoryItem
 import kotlinx.coroutines.flow.Flow
 
 interface HistoryRepository {
-    fun getHistoryWithItems(): Flow<Map<History, List<HistoryItem>>>
-    suspend fun insertHistoryWithItems(items: List<HistoryItem>)
+    fun getHistoryWithItems(): Flow<Result<Map<History, List<HistoryItem>>>>
+    suspend fun insertHistoryWithItems(items: List<HistoryItem>): Result<Unit>
 }

--- a/app/src/main/java/com/example/banchan/data/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/example/banchan/data/repository/HistoryRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.example.banchan.data.repository
+
+import com.example.banchan.data.source.HistoryDataSource
+import com.example.banchan.data.source.local.history.HistoryItem
+import javax.inject.Inject
+
+class HistoryRepositoryImpl @Inject constructor(
+    private val localDataSource: HistoryDataSource
+) : HistoryRepository {
+    override fun getHistoryWithItems() = localDataSource.getHistoryWithItems()
+
+    override suspend fun insertHistoryWithItems(items: List<HistoryItem>) {
+        localDataSource.insertHistoryWithItems(items)
+    }
+}

--- a/app/src/main/java/com/example/banchan/data/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/example/banchan/data/repository/HistoryRepositoryImpl.kt
@@ -9,7 +9,8 @@ class HistoryRepositoryImpl @Inject constructor(
 ) : HistoryRepository {
     override fun getHistoryWithItems() = localDataSource.getHistoryWithItems()
 
-    override suspend fun insertHistoryWithItems(items: List<HistoryItem>) {
-        localDataSource.insertHistoryWithItems(items)
-    }
+    override suspend fun insertHistoryWithItems(items: List<HistoryItem>): Result<Unit> =
+        runCatching {
+            localDataSource.insertHistoryWithItems(items)
+        }
 }

--- a/app/src/main/java/com/example/banchan/data/source/HistoryDataSource.kt
+++ b/app/src/main/java/com/example/banchan/data/source/HistoryDataSource.kt
@@ -1,0 +1,10 @@
+package com.example.banchan.data.source
+
+import com.example.banchan.data.source.local.history.History
+import com.example.banchan.data.source.local.history.HistoryItem
+import kotlinx.coroutines.flow.Flow
+
+interface HistoryDataSource {
+    fun getHistoryWithItems(): Flow<Map<History, List<HistoryItem>>>
+    suspend fun insertHistoryWithItems(items: List<HistoryItem>)
+}

--- a/app/src/main/java/com/example/banchan/data/source/HistoryDataSource.kt
+++ b/app/src/main/java/com/example/banchan/data/source/HistoryDataSource.kt
@@ -5,6 +5,6 @@ import com.example.banchan.data.source.local.history.HistoryItem
 import kotlinx.coroutines.flow.Flow
 
 interface HistoryDataSource {
-    fun getHistoryWithItems(): Flow<Map<History, List<HistoryItem>>>
-    suspend fun insertHistoryWithItems(items: List<HistoryItem>)
+    fun getHistoryWithItems(): Flow<Result<Map<History, List<HistoryItem>>>>
+    suspend fun insertHistoryWithItems(items: List<HistoryItem>): Result<Unit>
 }

--- a/app/src/main/java/com/example/banchan/data/source/local/BanChanDatabase.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/BanChanDatabase.kt
@@ -6,12 +6,20 @@ import androidx.room.TypeConverters
 import com.example.banchan.data.Converter
 import com.example.banchan.data.source.local.basket.BasketDao
 import com.example.banchan.data.source.local.basket.BasketItem
+import com.example.banchan.data.source.local.history.History
+import com.example.banchan.data.source.local.history.HistoryDao
+import com.example.banchan.data.source.local.history.HistoryItem
 import com.example.banchan.data.source.local.recent.RecentlyProduct
 import com.example.banchan.data.source.local.recent.RecentlyProductDao
 
-@Database(entities = [BasketItem::class, RecentlyProduct::class], version = 1, exportSchema = false)
+@Database(
+    entities = [BasketItem::class, RecentlyProduct::class, History::class, HistoryItem::class],
+    version = 1,
+    exportSchema = false
+)
 @TypeConverters(Converter::class)
 abstract class BanChanDatabase : RoomDatabase() {
     abstract fun basketDao(): BasketDao
     abstract fun recentlyProductDao(): RecentlyProductDao
+    abstract fun historyDao(): HistoryDao
 }

--- a/app/src/main/java/com/example/banchan/data/source/local/history/History.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/history/History.kt
@@ -2,9 +2,12 @@ package com.example.banchan.data.source.local.history
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.*
 
 @Entity
 data class History(
     @PrimaryKey(autoGenerate = true)
-    val id: Long
+    val id: Long,
+    val date: Date = Date(),
+    val remainTime: Int = 20
 )

--- a/app/src/main/java/com/example/banchan/data/source/local/history/History.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/history/History.kt
@@ -1,0 +1,10 @@
+package com.example.banchan.data.source.local.history
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
+data class History(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long
+)

--- a/app/src/main/java/com/example/banchan/data/source/local/history/HistoryDao.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/history/HistoryDao.kt
@@ -1,0 +1,27 @@
+package com.example.banchan.data.source.local.history
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface HistoryDao {
+    @Query("select * from history left join historyitem on historyitem.historyId = history.id")
+    fun getHistoryWithItems(): Flow<Map<History, List<HistoryItem>>>
+
+    @Insert
+    suspend fun insertHistory(history: History): Long
+
+    @Insert
+    suspend fun insertHistoryItem(vararg historyItem: HistoryItem)
+
+    @Transaction
+    suspend fun insertHistoryWithItems(historyItem: List<HistoryItem>) {
+        val id = insertHistory(History(id = 0))
+        historyItem.forEach {
+            insertHistoryItem(it.copy(historyId = id))
+        }
+    }
+}

--- a/app/src/main/java/com/example/banchan/data/source/local/history/HistoryItem.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/history/HistoryItem.kt
@@ -6,8 +6,8 @@ import androidx.room.PrimaryKey
 @Entity
 data class HistoryItem(
     @PrimaryKey(autoGenerate = true)
-    val itemId: Long,
-    val historyId: Long,
+    val itemId: Long = 0,
+    val historyId: Long = 0,
     val imageUrl: String,
     val count: Int,
     val originPrice: Int,

--- a/app/src/main/java/com/example/banchan/data/source/local/history/HistoryItem.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/history/HistoryItem.kt
@@ -1,0 +1,15 @@
+package com.example.banchan.data.source.local.history
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
+data class HistoryItem(
+    @PrimaryKey(autoGenerate = true)
+    val itemId: Long,
+    val historyId: Long,
+    val imageUrl: String,
+    val count: Int,
+    val originPrice: Int,
+    val name: String
+)

--- a/app/src/main/java/com/example/banchan/data/source/local/history/HistoryLocalDataSource.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/history/HistoryLocalDataSource.kt
@@ -1,0 +1,22 @@
+package com.example.banchan.data.source.local.history
+
+import com.example.banchan.data.source.HistoryDataSource
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class HistoryLocalDataSource @Inject constructor(
+    private val historyDao: HistoryDao,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : HistoryDataSource {
+    override fun getHistoryWithItems() = historyDao.getHistoryWithItems()
+
+
+    override suspend fun insertHistoryWithItems(items: List<HistoryItem>) {
+        withContext(ioDispatcher) {
+            historyDao.insertHistoryWithItems(items)
+        }
+    }
+}

--- a/app/src/main/java/com/example/banchan/data/source/local/history/HistoryLocalDataSource.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/history/HistoryLocalDataSource.kt
@@ -3,7 +3,8 @@ package com.example.banchan.data.source.local.history
 import com.example.banchan.data.source.HistoryDataSource
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -11,10 +12,13 @@ class HistoryLocalDataSource @Inject constructor(
     private val historyDao: HistoryDao,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : HistoryDataSource {
-    override fun getHistoryWithItems() = historyDao.getHistoryWithItems()
+    override fun getHistoryWithItems() = historyDao.getHistoryWithItems().map {
+        Result.success(it)
+    }.catch { exception ->
+        Result.failure<Exception>(exception)
+    }
 
-
-    override suspend fun insertHistoryWithItems(items: List<HistoryItem>) {
+    override suspend fun insertHistoryWithItems(items: List<HistoryItem>) = runCatching {
         withContext(ioDispatcher) {
             historyDao.insertHistoryWithItems(items)
         }

--- a/app/src/main/java/com/example/banchan/di/DataSourceModule.kt
+++ b/app/src/main/java/com/example/banchan/di/DataSourceModule.kt
@@ -2,8 +2,10 @@ package com.example.banchan.di
 
 import com.example.banchan.data.source.BanChanDataSource
 import com.example.banchan.data.source.BasketDataSource
+import com.example.banchan.data.source.HistoryDataSource
 import com.example.banchan.data.source.RecentlyProductDataSource
 import com.example.banchan.data.source.local.basket.BasketLocalDataSource
+import com.example.banchan.data.source.local.history.HistoryLocalDataSource
 import com.example.banchan.data.source.local.recent.RecentlyProductLocalDataSource
 import com.example.banchan.data.source.remote.BanChanRemoteDataSource
 import dagger.Binds
@@ -33,5 +35,11 @@ abstract class DataSourceModule {
     abstract fun bindRecentlyProductLocalDataSource(
         recentlyProductLocalDataSource: RecentlyProductLocalDataSource
     ): RecentlyProductDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindHistoryLocalDataSource(
+        historyLocalDataSource: HistoryLocalDataSource
+    ): HistoryDataSource
 }
 

--- a/app/src/main/java/com/example/banchan/di/DatabaseModule.kt
+++ b/app/src/main/java/com/example/banchan/di/DatabaseModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.room.Room
 import com.example.banchan.data.source.local.BanChanDatabase
 import com.example.banchan.data.source.local.basket.BasketDao
+import com.example.banchan.data.source.local.history.HistoryDao
 import com.example.banchan.data.source.local.recent.RecentlyProductDao
 import dagger.Module
 import dagger.Provides
@@ -34,4 +35,9 @@ object DatabaseModule {
     @Provides
     fun provideRecentlyProductDao(database: BanChanDatabase): RecentlyProductDao =
         database.recentlyProductDao()
+
+    @Singleton
+    @Provides
+    fun provideHistoryDao(database: BanChanDatabase): HistoryDao =
+        database.historyDao()
 }

--- a/app/src/main/java/com/example/banchan/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/banchan/di/RepositoryModule.kt
@@ -28,4 +28,10 @@ abstract class RepositoryModule {
     abstract fun bindRecentlyProductRepository(
         recentlyProductRepositoryImpl: RecentlyProductRepositoryImpl
     ): RecentlyProductRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindHistoryRepository(
+        historyRepositoryImpl: HistoryRepositoryImpl
+    ): HistoryRepository
 }

--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookViewModel.kt
@@ -2,6 +2,8 @@ package com.example.banchan.presentation.home.maincook
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.banchan.data.repository.HistoryRepository
+import com.example.banchan.data.source.local.history.HistoryItem
 import com.example.banchan.domain.usecase.GetMainDishesUseCase
 import com.example.banchan.presentation.adapter.main.MainItemListModel
 import com.example.banchan.presentation.adapter.main.Type
@@ -14,7 +16,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MainCookViewModel @Inject constructor(
-    private val getMainDishesUseCase: GetMainDishesUseCase
+    private val getMainDishesUseCase: GetMainDishesUseCase,
+    private val historyRepository: HistoryRepository
 ) : ViewModel() {
     var type = Type.Grid
         private set
@@ -26,6 +29,28 @@ class MainCookViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             _dishes.emit(makeItemModel(type, filter))
+        }
+
+        viewModelScope.launch {
+            historyRepository.insertHistoryWithItems(
+                listOf(
+                    HistoryItem(
+                        imageUrl = "s",
+                        originPrice = 1,
+                        count = 1,
+                        name = "s"
+                    ),
+                    HistoryItem(
+                        imageUrl = "s",
+                        originPrice = 1,
+                        count = 1,
+                        name = "s"
+                    )
+                )
+            )
+            historyRepository.getHistoryWithItems().collect {
+                println(it)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
내역 DB 구현, datasource, repository 구현

## Main Changes
- 내역 DB 구현, datasource, repository 구현

**내역 추가하는 방법**
<img width="478" alt="image" src="https://user-images.githubusercontent.com/54823396/184546427-67e772bd-aec4-4264-89f1-b0ea6ad0cd9a.png">
**조회하는 방법**
<img width="478" alt="image" src="https://user-images.githubusercontent.com/54823396/184545345-408fc173-eca6-4e97-a6ba-1b9f0b96b13e.png">
**조회 결과**
```System.out: {History(id=1, date=Mon Aug 15 01:37:14 GMT+09:00 2022, remainTime=20)=[HistoryItem(itemId=1, historyId=1, imageUrl=s, count=1, originPrice=1, name=s), HistoryItem(itemId=2, historyId=1, imageUrl=s, count=1, originPrice=1, name=s)]}```

Closes #37 
