### PR TITLE
[FEAT] 상품 상세화면 구현

### DIFF
--- a/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductDetailImageViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductDetailImageViewHolder.kt
@@ -1,0 +1,26 @@
+package com.example.banchan.presentation.adapter.productdetail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.databinding.ItemDetailImageSliderBinding
+
+class ProductDetailImageViewHolder(
+    private val binding: ItemDetailImageSliderBinding
+) : RecyclerView.ViewHolder(binding.root) {
+
+    companion object {
+        fun create(parent: ViewGroup) = ProductDetailImageViewHolder(
+            ItemDetailImageSliderBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+    fun bindImage(imageURL : String) {
+        binding.imageUrl = imageURL
+    }
+
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductDetailSectionAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductDetailSectionAdapter.kt
@@ -1,0 +1,29 @@
+package com.example.banchan.presentation.adapter.productdetail
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+
+class ProductDetailSectionAdapter(
+) : RecyclerView.Adapter<ProductDetailSectionViewHolder>() {
+
+    private val sectionList: MutableList<String> = mutableListOf()
+
+    fun setSectionList(sectionList: List<String>){
+        this.sectionList.clear()
+        this.sectionList.addAll(sectionList)
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): ProductDetailSectionViewHolder =
+        ProductDetailSectionViewHolder.create(parent)
+
+    override fun onBindViewHolder(holder: ProductDetailSectionViewHolder, position: Int) {
+        holder.bind(sectionList[position])
+    }
+
+    override fun getItemCount(): Int = sectionList.size
+
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductDetailSectionViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductDetailSectionViewHolder.kt
@@ -1,0 +1,27 @@
+package com.example.banchan.presentation.adapter.productdetail
+
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.databinding.ItemDetailSectionBinding
+
+class ProductDetailSectionViewHolder(
+    private val binding: ItemDetailSectionBinding
+) : RecyclerView.ViewHolder(binding.root) {
+
+    companion object {
+        fun create(parent: ViewGroup) = ProductDetailSectionViewHolder(
+            ItemDetailSectionBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+    fun bind(image : String) {
+        binding.imageUrl = image
+    }
+
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductDetailSliderAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductDetailSliderAdapter.kt
@@ -1,0 +1,21 @@
+package com.example.banchan.presentation.adapter.productdetail
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+
+class ProductDetailSliderAdapter(
+    private val thumbImageUrls: List<String>
+) : RecyclerView.Adapter<ProductDetailImageViewHolder>() {
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): ProductDetailImageViewHolder =
+        ProductDetailImageViewHolder.create(parent)
+
+    override fun onBindViewHolder(holder: ProductDetailImageViewHolder, position: Int) {
+        holder.bindImage(thumbImageUrls[position])
+    }
+
+    override fun getItemCount(): Int = thumbImageUrls.size
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductDetailThumbNailAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductDetailThumbNailAdapter.kt
@@ -1,0 +1,28 @@
+package com.example.banchan.presentation.adapter.productdetail
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+
+class ProductDetailThumbNailAdapter: RecyclerView.Adapter<ProductThumbNailViewHolder>() {
+
+    private val thumbImageUrls: MutableList<String> = mutableListOf()
+
+    fun setThumbImageUrls(thumbImageUrls: List<String>){
+        this.thumbImageUrls.clear()
+        this.thumbImageUrls.addAll(thumbImageUrls)
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): ProductThumbNailViewHolder =
+        ProductThumbNailViewHolder.create(parent)
+
+    override fun onBindViewHolder(holder: ProductThumbNailViewHolder, position: Int) {
+        holder.bind(thumbImageUrls)
+    }
+
+    override fun getItemCount(): Int = 1
+
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductInfoAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductInfoAdapter.kt
@@ -1,0 +1,49 @@
+package com.example.banchan.presentation.adapter.productdetail
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.domain.model.ProductDetailModel
+
+class ProductInfoAdapter(
+    private val onMinusClick: () -> Unit,
+    private val onPlusClick: () -> Unit,
+    private val onBasketAddClick: () -> Unit,
+) : RecyclerView.Adapter<ProductInfoViewHolder>() {
+
+    private var productInfo: ProductDetailModel? = null
+    private var amount: Int = 1
+
+    fun setProductInfo(productInfo: ProductDetailModel, amount : Int) {
+        this.productInfo = productInfo
+        this.amount = amount
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductInfoViewHolder {
+        return ProductInfoViewHolder.create(parent)
+    }
+
+    override fun onBindViewHolder(holder: ProductInfoViewHolder, position: Int) {
+        holder.bind(productInfo, amount, onMinusClick, onPlusClick, onBasketAddClick)
+    }
+
+    override fun onBindViewHolder(
+        holder: ProductInfoViewHolder,
+        position: Int,
+        payloads: MutableList<Any>
+    ) {
+        if (payloads.isEmpty()) {
+            super.onBindViewHolder(holder, position, payloads)
+        } else {
+            val amount = payloads[0]
+            if (amount is Int) {
+                holder.bindAmount(amount)
+            } else {
+                super.onBindViewHolder(holder, position, payloads)
+            }
+        }
+    }
+
+    override fun getItemCount(): Int = 1
+
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductInfoViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductInfoViewHolder.kt
@@ -1,0 +1,46 @@
+package com.example.banchan.presentation.adapter.productdetail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.databinding.ItemDetailOrderBinding
+import com.example.banchan.domain.model.ProductDetailModel
+import com.example.banchan.util.ext.onMinusClick
+import com.example.banchan.util.ext.onPlusClick
+
+class ProductInfoViewHolder(
+    private val binding: ItemDetailOrderBinding,
+) : RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(
+        productInfo: ProductDetailModel?,
+        amount: Int,
+        onMinusClick: () -> Unit,
+        onPlusClick: () -> Unit,
+        onBasketAddClick: () -> Unit,
+    ) {
+        binding.productDetail = productInfo
+        binding.amount = amount
+        binding.counterDetailAmount.onMinusClick{ onMinusClick() }
+        binding.counterDetailAmount.onPlusClick{ onPlusClick() }
+        binding.btnDetailProductOrder.setOnClickListener { onBasketAddClick() }
+    }
+
+    fun bindAmount(
+        amount: Int
+    ) {
+        binding.amount = amount
+        binding.executePendingBindings()
+    }
+
+    companion object {
+        fun create(parent: ViewGroup) = ProductInfoViewHolder(
+            ItemDetailOrderBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductThumbNailViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/productdetail/ProductThumbNailViewHolder.kt
@@ -1,0 +1,29 @@
+package com.example.banchan.presentation.adapter.productdetail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.databinding.ItemDetailThumbnailBinding
+import com.google.android.material.tabs.TabLayoutMediator
+
+class ProductThumbNailViewHolder(
+    private val binding: ItemDetailThumbnailBinding,
+) : RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(imageUrls : List<String>) {
+        binding.vpDetailThumbnail.adapter = ProductDetailSliderAdapter(imageUrls)
+        TabLayoutMediator(binding.tlDetailSelector, binding.vpDetailThumbnail) { tab, position ->
+        }.attach()
+    }
+
+    companion object {
+        fun create(parent: ViewGroup) = ProductThumbNailViewHolder(
+            ItemDetailThumbnailBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+}

--- a/app/src/main/java/com/example/banchan/presentation/productdetail/ProductDetailFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/productdetail/ProductDetailFragment.kt
@@ -1,0 +1,115 @@
+
+package com.example.banchan.presentation.productdetail
+
+import android.view.View
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.ConcatAdapter
+import com.example.banchan.R
+import com.example.banchan.databinding.FragmentProductDetailBinding
+import com.example.banchan.domain.model.BasketModel
+import com.example.banchan.domain.model.ProductDetailModel
+import com.example.banchan.domain.model.ResponseState
+import com.example.banchan.presentation.adapter.productdetail.*
+import com.example.banchan.presentation.base.BaseFragment
+import com.example.banchan.presentation.dialog.BasketCheckDialog
+import com.example.banchan.presentation.main.BasketViewModel
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class ProductDetailFragment : BaseFragment<FragmentProductDetailBinding>(R.layout.fragment_product_detail) {
+
+    private val basketViewModel: BasketViewModel by activityViewModels()
+    private val productDetailViewModel: ProductDetailViewModel by viewModels()
+
+    private val onMinusClick: (()->Unit) = { basketViewModel.basketCountDecrease() }
+    private val onPlusClick: (()->Unit) = { basketViewModel.basketCountIncrease() }
+    private val onBasketAddClick: (()->Unit) = {
+        addBasket()
+        showDialog()
+    }
+
+    private val thumbnailAdapter by lazy { ProductDetailThumbNailAdapter() }
+    private val productDetailAdapter by lazy { ProductInfoAdapter(onMinusClick, onPlusClick, onBasketAddClick) }
+    private val productDetailSectionAdapter by lazy { ProductDetailSectionAdapter() }
+
+    override fun observe() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    productDetailViewModel.productDetail.collectLatest {
+                        if (it is ResponseState.Success) {
+                            setRecyclerViewData(it.data!!)
+                            binding.rvProductDetail.visibility = View.VISIBLE
+                            binding.pbDetailLoading.visibility = View.INVISIBLE
+                        } else {
+                            binding.rvProductDetail.visibility = View.INVISIBLE
+                            binding.pbDetailLoading.visibility = View.VISIBLE
+                        }
+                    }
+                }
+
+                launch {
+                    basketViewModel.basketList.collectLatest {
+                        binding.abProductDetail.setCartCount(it.size)
+                    }
+                }
+            }
+        }
+
+        basketViewModel.selectedBasketCount.observe(viewLifecycleOwner) {
+            productDetailAdapter.notifyItemChanged(0, it)
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        productDetailViewModel.getProductDetail(
+            basketViewModel.selectedBasketItem.value!!.detailHash,
+            basketViewModel.selectedBasketItem.value!!.title
+        )
+    }
+
+    override fun initViews() {
+        initRecyclerView()
+    }
+
+    private fun initRecyclerView() {
+        binding.rvProductDetail.adapter = ConcatAdapter(thumbnailAdapter, productDetailAdapter, productDetailSectionAdapter)
+    }
+
+    private fun setRecyclerViewData(productDetail: ProductDetailModel) {
+        thumbnailAdapter.setThumbImageUrls(productDetail.thumbImages)
+        productDetailAdapter.setProductInfo(productDetail, basketViewModel.selectedBasketCount.value!!)
+        productDetailSectionAdapter.setSectionList(productDetail.detailSection)
+    }
+
+    private fun addBasket() {
+        with(basketViewModel) {
+            addBasketList(
+                BasketModel(
+                    count = selectedBasketCount.value!!,
+                    image = selectedBasketItem.value!!.image,
+                    price = selectedBasketItem.value!!.originPrice,
+                    name = selectedBasketItem.value!!.title,
+                    detailHash = selectedBasketItem.value!!.detailHash
+                )
+            )
+        }
+    }
+
+    private fun showDialog() {
+        val targetDialog = parentFragmentManager.findFragmentByTag(BasketCheckDialog.TAG)
+        if (targetDialog == null) {
+            val checkDialog = BasketCheckDialog()
+            checkDialog.isCancelable = false
+            checkDialog.show(parentFragmentManager, BasketCheckDialog.TAG)
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/banchan/presentation/productdetail/ProductDetailViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/productdetail/ProductDetailViewModel.kt
@@ -26,8 +26,10 @@ class ProductDetailViewModel @Inject constructor(
                 if (result.isSuccess) {
                     val detailModel = result.getOrThrow().toDetailModel(name)
                     _productDetail.emit(ResponseState.Success(detailModel))
-                } else {
+                } else if(result.isFailure) {
                     _productDetail.emit(ResponseState.Error(result.exceptionOrNull()))
+                } else {
+
                 }
             }
         }

--- a/app/src/main/java/com/example/banchan/util/ext/BindingAdapters.kt
+++ b/app/src/main/java/com/example/banchan/util/ext/BindingAdapters.kt
@@ -10,3 +10,11 @@ fun ImageView.setImageFromUrl(url: String) {
         .load(url)
         .into(this)
 }
+
+@BindingAdapter("sectionUrl")
+fun ImageView.setSectionImage(url: String) {
+    Glide.with(this.context)
+        .load(url)
+        .override(1000,1000)
+        .into(this)
+}

--- a/app/src/main/res/layout/bottomsheet_basket.xml
+++ b/app/src/main/res/layout/bottomsheet_basket.xml
@@ -131,6 +131,7 @@
             style="@style/common_button_style"
             android:layout_marginBottom="16dp"
             android:layout_marginTop="24dp"
+            android:layout_marginHorizontal="16dp"
             android:text="@{@string/bottom_sheet_basket_count(vm.selectedBasketCount)}"
             app:layout_constraintTop_toBottomOf="@id/amount_counter"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_product_detail.xml
+++ b/app/src/main/res/layout/fragment_product_detail.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.productdetail.ProductDetailFragment">
+
+        <com.example.banchan.presentation.custom.OrderingAppBar
+            android:id="@+id/ab_product_detail"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            app:layout_constraintTop_toTopOf="parent"/>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_product_detail"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ab_product_detail"/>
+
+        <ProgressBar
+            android:id="@+id/pb_detail_loading"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="@+id/rv_product_detail"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/ab_product_detail" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_detail_image_slider.xml
+++ b/app/src/main/res/layout/item_detail_image_slider.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+
+        <variable
+            name="imageUrl"
+            type="String" />
+    </data>
+
+    <ImageView
+        android:id="@+id/iv_detail_image_slider"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="centerCrop"
+        imageUrl="@{imageUrl}">
+    </ImageView>
+</layout>

--- a/app/src/main/res/layout/item_detail_order.xml
+++ b/app/src/main/res/layout/item_detail_order.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <import type="android.view.View" />
+
+        <variable
+            name="productDetail"
+            type="com.example.banchan.domain.model.ProductDetailModel" />
+
+        <variable
+            name="amount"
+            type="Integer" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/gl_detail_start"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_begin="16dp" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/gl_detail_end"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_end="16dp" />
+
+        <TextView
+            android:id="@+id/tv_detail_product_name"
+            style="@style/tv_normal_32"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@{productDetail.name}"
+            app:layout_constraintEnd_toStartOf="@id/gl_detail_end"
+            app:layout_constraintStart_toEndOf="@id/gl_detail_start"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="오리 주물럭_반조리" />
+
+        <TextView
+            android:id="@+id/tv_detail_product_description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@{productDetail.description}"
+            android:textColor="@color/greyscale_default"
+            android:textSize="18sp"
+            app:layout_constraintEnd_toStartOf="@id/gl_detail_end"
+            app:layout_constraintStart_toEndOf="@id/gl_detail_start"
+            app:layout_constraintTop_toBottomOf="@id/tv_detail_product_name"
+            tools:text="감칠맛 나는 매콤한 양념" />
+
+        <TextView
+            android:id="@+id/tv_detail_product_percent"
+            style="@style/tv_normal_14.Sale"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{@string/product_detail_discount_percent(productDetail.discountPercent)}"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:visibility="@{productDetail.discountPercent == null ? View.GONE : View.VISIBLE}"
+            app:layout_constraintStart_toEndOf="@id/gl_detail_start"
+            app:layout_constraintTop_toTopOf="@id/tv_detail_display_price"
+            tools:text="20%" />
+
+        <TextView
+            android:id="@+id/tv_detail_display_price"
+            style="@style/tv_normal_14.Black"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:layout_marginTop="8dp"
+            android:text="@{productDetail.discountPercent == null ? @string/product_detail_price(productDetail.originPrice) : @string/product_detail_price(productDetail.discountPrice)}"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toEndOf="@id/tv_detail_product_percent"
+            app:layout_constraintTop_toBottomOf="@id/tv_detail_product_description"
+            tools:text="12,640원" />
+
+        <TextView
+            android:id="@+id/tv_detail_origin_price"
+            style="@style/tv_normal_12.GreyDefault"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:background="@drawable/background_line"
+            android:text="@{@string/product_detail_price(productDetail.originPrice)}"
+            android:textSize="14sp"
+            android:visibility="@{productDetail.discountPercent == null ? View.GONE : View.VISIBLE}"
+            app:layout_constraintBottom_toBottomOf="@id/tv_detail_product_percent"
+            app:layout_constraintStart_toEndOf="@id/tv_detail_display_price"
+            tools:text="15,800원" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:id="@+id/dv_delivery_info"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginTop="24dp"
+            app:layout_constraintEnd_toStartOf="@id/gl_detail_end"
+            app:layout_constraintStart_toEndOf="@id/gl_detail_start"
+            app:layout_constraintTop_toBottomOf="@id/tv_detail_display_price" />
+
+        <TextView
+            android:id="@+id/tv_detail_point_title"
+            style="@style/tv_normal_12.GreyDefault"
+            android:layout_width="60dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/product_detail_point"
+            android:textSize="14sp"
+            app:layout_constraintStart_toEndOf="@id/gl_detail_start"
+            app:layout_constraintTop_toBottomOf="@id/dv_delivery_info" />
+
+        <TextView
+            android:id="@+id/tv_detail_delivery_info_title"
+            style="@style/tv_normal_12.GreyDefault"
+            android:layout_width="60dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/product_detail_delivery_info"
+            android:textSize="14sp"
+            app:layout_constraintStart_toEndOf="@id/gl_detail_start"
+            app:layout_constraintTop_toBottomOf="@id/tv_detail_point_title" />
+
+        <TextView
+            android:id="@+id/tv_detail_delivery_fee_title"
+            style="@style/tv_normal_12.GreyDefault"
+            android:layout_width="60dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/product_detail_delivery_fee"
+            android:textSize="14sp"
+            app:layout_constraintStart_toEndOf="@id/gl_detail_start"
+            app:layout_constraintTop_toBottomOf="@id/tv_detail_delivery_info_title" />
+
+        <TextView
+            android:id="@+id/tv_detail_point"
+            style="@style/tv_normal_12.GreyDefault"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:text="@{@string/product_detail_price(productDetail.point)}"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toStartOf="@id/gl_detail_end"
+            app:layout_constraintStart_toEndOf="@id/tv_detail_point_title"
+            app:layout_constraintTop_toTopOf="@id/tv_detail_point_title"
+            tools:text="126원" />
+
+        <TextView
+            android:id="@+id/tv_detail_delivery_info"
+            style="@style/tv_normal_12.GreyDefault"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:text="@{productDetail.deliveryInfo}"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toStartOf="@id/gl_detail_end"
+            app:layout_constraintStart_toEndOf="@id/tv_detail_delivery_info_title"
+            app:layout_constraintTop_toTopOf="@id/tv_detail_delivery_info_title"
+            tools:text="서울 경기 새벽 배송, 전국 택배 배송" />
+
+        <TextView
+            android:id="@+id/tv_detail_delivery_fee"
+            style="@style/tv_normal_12.GreyDefault"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:text="@{productDetail.deliveryFee}"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toStartOf="@id/gl_detail_end"
+            app:layout_constraintStart_toEndOf="@id/tv_detail_delivery_fee_title"
+            app:layout_constraintTop_toTopOf="@id/tv_detail_delivery_fee_title"
+            tools:text="2,500원 (40,000원 이상 구매 시 무료)" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:id="@+id/dv_delivery_count"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginTop="24dp"
+            app:layout_constraintEnd_toStartOf="@id/gl_detail_end"
+            app:layout_constraintStart_toEndOf="@id/gl_detail_start"
+            app:layout_constraintTop_toBottomOf="@id/tv_detail_delivery_fee_title" />
+
+        <TextView
+            android:id="@+id/tv_detail_amount"
+            style="@style/tv_normal_12.GreyDefault"
+            android:layout_width="60dp"
+            android:layout_height="wrap_content"
+            android:text="@string/product_detail_amount"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toTopOf="@id/dv_delivery_sum"
+            app:layout_constraintStart_toEndOf="@id/gl_detail_start"
+            app:layout_constraintTop_toBottomOf="@id/dv_delivery_count" />
+
+        <com.example.banchan.presentation.custom.AmountCounter
+            android:id="@+id/counter_detail_amount"
+            android:layout_width="146dp"
+            android:layout_height="44dp"
+            app:amount="@{amount}"
+            app:layout_constraintBottom_toTopOf="@id/dv_delivery_sum"
+            app:layout_constraintEnd_toStartOf="@id/gl_detail_end"
+            app:layout_constraintTop_toBottomOf="@id/dv_delivery_count" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:id="@+id/dv_delivery_sum"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginTop="92dp"
+            app:layout_constraintEnd_toStartOf="@id/gl_detail_end"
+            app:layout_constraintStart_toEndOf="@id/gl_detail_start"
+            app:layout_constraintTop_toBottomOf="@id/dv_delivery_count" />
+
+        <TextView
+            android:id="@+id/tv_detail_sum_price"
+            style="@style/tv_normal_32"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@{productDetail.discountPercent == null ? @string/product_detail_price(amount * productDetail.originPrice) : @string/product_detail_price(amount * productDetail.discountPrice)}"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toStartOf="@id/gl_detail_end"
+            app:layout_constraintTop_toBottomOf="@id/dv_delivery_sum" />
+
+        <TextView
+            android:id="@+id/tv_detail_sum_price_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="24dp"
+            android:text="총 주문금액"
+            android:textColor="@color/greyscale_default"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@id/tv_detail_sum_price"
+            app:layout_constraintEnd_toStartOf="@id/tv_detail_sum_price"
+            app:layout_constraintTop_toTopOf="@id/tv_detail_sum_price" />
+
+        <Button
+            android:id="@+id/btn_detail_product_order"
+            style="@style/common_button_style"
+            android:layout_width="0dp"
+            android:layout_height="56dp"
+            android:layout_marginHorizontal="0dp"
+            android:layout_marginTop="24dp"
+            android:text="주문하기"
+            app:layout_constraintEnd_toStartOf="@id/gl_detail_end"
+            app:layout_constraintStart_toEndOf="@id/gl_detail_start"
+            app:layout_constraintTop_toBottomOf="@id/tv_detail_sum_price" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_detail_section.xml
+++ b/app/src/main/res/layout/item_detail_section.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="imageUrl"
+            type="String" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/iv_detail_image_slider"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:adjustViewBounds="true"
+            android:layout_marginHorizontal="16dp"
+            app:layout_constraintTop_toTopOf="parent"
+            sectionUrl="@{imageUrl}">
+        </ImageView>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_detail_thumbnail.xml
+++ b/app/src/main/res/layout/item_detail_thumbnail.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintTop_toTopOf="parent" >
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/vp_detail_thumbnail"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tl_detail_selector"
+            android:layout_width="wrap_content"
+            android:layout_height="4dp"
+            android:layout_gravity="bottom"
+            android:layout_marginStart="13dp"
+            android:layout_marginBottom="16dp"
+            android:background="@android:color/transparent"
+            app:tabBackground="@drawable/product_detail_tab_selector"
+            app:tabGravity="center"
+            app:tabIndicator="@null"
+            app:tabIndicatorHeight="0dp"
+            app:tabMinWidth="40dp"
+            app:tabMaxWidth="40dp"/>
+    </FrameLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,13 @@
     <string name="dialog_basket_check">장바구니 확인</string>
     <string name="dialog_basket_continue">계속 쇼핑하기</string>
 
+    <string name="product_detail_discount_percent">%d%%</string>
+    <string name="product_detail_price">%,d원</string>
+    <string name="product_detail_point">적립금</string>
+    <string name="product_detail_delivery_info">배송정보</string>
+    <string name="product_detail_delivery_fee">배송비</string>
+    <string name="product_detail_amount">수량</string>
+
     <string-array name="home_tab_title_array">
         <item>기획전</item>
         <item>든든한 메인요리</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -36,8 +36,6 @@
         <item name="backgroundTint">@color/primary_main</item>
         <item name="android:layout_height">56dp</item>
         <item name="android:layout_width">0dp</item>
-        <item name="android:layout_marginStart">16dp</item>
-        <item name="android:layout_marginEnd">16dp</item>
         <item name="android:inset">16dp</item>
         <item name="android:textSize">18sp</item>
         <item name="android:textColor">@color/white</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -24,6 +24,10 @@
         <item name="android:textSize">12sp</item>
     </style>
 
+    <style name="tv_normal_32" parent="TextAppearance.AppCompat">
+        <item name="android:textSize">32sp</item>
+    </style>
+
     <style name="tv_normal_14.Sale">
         <item name="android:textColor">
             @color/primary_accent


### PR DESCRIPTION
## Summary
- 상품 상세화면을 구현합니다.

## Main Changes
- [x] 상단 Thumbnail Viewpager 구현
- [x] 중단 상품정보 Adapter, ViewHolder 구현
- [x] 하단 Section Image Adapter, ViewHolder 구현
- [x] Concat 어댑터로 묶어서 화면에 보여주기

Closes #40

- 
![image](https://user-images.githubusercontent.com/29484377/184816961-690912e5-e1c4-4362-8d80-43a37efdb675.png)
-
![test](https://user-images.githubusercontent.com/29484377/184817011-a05761c8-8abd-472d-8e55-d82f3418d12d.gif)

