### PR TITLE
[FEAT] 주문 상태 화면 UI 및 로직 일부 구현 #46

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -25,7 +25,7 @@
         <entry key="app/src/main/res/layout/fragment_best.xml" value="0.2" />
         <entry key="app/src/main/res/layout/fragment_home.xml" value="0.16302083333333334" />
         <entry key="app/src/main/res/layout/fragment_main_cook.xml" value="0.25" />
-        <entry key="app/src/main/res/layout/fragment_order_success.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_order_success.xml" value="0.36054840087890627" />
         <entry key="app/src/main/res/layout/fragment_side.xml" value="0.16302083333333334" />
         <entry key="app/src/main/res/layout/fragment_soup.xml" value="0.33" />
         <entry key="app/src/main/res/layout/item_banchan.xml" value="0.5686782836914064" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -25,6 +25,7 @@
         <entry key="app/src/main/res/layout/fragment_best.xml" value="0.2" />
         <entry key="app/src/main/res/layout/fragment_home.xml" value="0.16302083333333334" />
         <entry key="app/src/main/res/layout/fragment_main_cook.xml" value="0.25" />
+        <entry key="app/src/main/res/layout/fragment_order_success.xml" value="0.1" />
         <entry key="app/src/main/res/layout/fragment_side.xml" value="0.16302083333333334" />
         <entry key="app/src/main/res/layout/fragment_soup.xml" value="0.33" />
         <entry key="app/src/main/res/layout/item_banchan.xml" value="0.5686782836914064" />
@@ -34,7 +35,12 @@
         <entry key="app/src/main/res/layout/item_home_header.xml" value="0.33410672853828305" />
         <entry key="app/src/main/res/layout/item_home_loading.xml" value="0.375" />
         <entry key="app/src/main/res/layout/item_menu.xml" value="0.33" />
+        <entry key="app/src/main/res/layout/item_menu_large.xml" value="0.1" />
         <entry key="app/src/main/res/layout/item_menu_medium.xml" value="0.12708333333333333" />
+        <entry key="app/src/main/res/layout/item_order_header.xml" value="0.10507246376811594" />
+        <entry key="app/src/main/res/layout/item_order_success.xml" value="0.24414715719063546" />
+        <entry key="app/src/main/res/layout/item_order_success_header.xml" value="0.3371170043945313" />
+        <entry key="app/src/main/res/layout/item_success_footer.xml" value="0.2538650512695313" />
         <entry key="app/src/main/res/layout/layout_home_main_title.xml" value="0.33" />
       </map>
     </option>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service android:name=".OrderService" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/banchan/BanChanApp.kt
+++ b/app/src/main/java/com/example/banchan/BanChanApp.kt
@@ -1,8 +1,15 @@
 package com.example.banchan
 
 import android.app.Application
+import android.content.Intent
 import dagger.hilt.android.HiltAndroidApp
+
 
 @HiltAndroidApp
 class BanChanApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        startService(Intent(this, OrderService::class.java))
+    }
 }

--- a/app/src/main/java/com/example/banchan/OrderService.kt
+++ b/app/src/main/java/com/example/banchan/OrderService.kt
@@ -1,0 +1,27 @@
+package com.example.banchan
+
+import androidx.lifecycle.LifecycleService
+import androidx.lifecycle.lifecycleScope
+import com.example.banchan.data.repository.HistoryRepository
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class OrderService : LifecycleService() {
+    @Inject
+    lateinit var historyRepository: HistoryRepository
+
+    override fun onCreate() {
+        super.onCreate()
+
+        lifecycleScope.launch {
+            while (isActive) {
+                historyRepository.updateAllHistory()
+                delay(1000 * 60)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/banchan/OrderService.kt
+++ b/app/src/main/java/com/example/banchan/OrderService.kt
@@ -2,7 +2,7 @@ package com.example.banchan
 
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
-import com.example.banchan.data.repository.HistoryRepository
+import com.example.banchan.domain.usecase.UpdateHistoryUseCase
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -12,14 +12,14 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class OrderService : LifecycleService() {
     @Inject
-    lateinit var historyRepository: HistoryRepository
+    lateinit var updateHistoryUseCase: UpdateHistoryUseCase
 
     override fun onCreate() {
         super.onCreate()
 
         lifecycleScope.launch {
             while (isActive) {
-                historyRepository.updateAllHistory()
+                updateHistoryUseCase()
                 delay(1000 * 60)
             }
         }

--- a/app/src/main/java/com/example/banchan/data/repository/HistoryRepository.kt
+++ b/app/src/main/java/com/example/banchan/data/repository/HistoryRepository.kt
@@ -9,4 +9,5 @@ interface HistoryRepository {
     fun getHistoryWithItems(): Flow<Result<List<HistoryWithItems>>>
     fun getHistoryWithItemsById(id: Int): Flow<Result<HistoryWithItems>>
     suspend fun insertHistoryWithItems(items: List<HistoryItem>): Result<Unit>
+    suspend fun updateAllHistory()
 }

--- a/app/src/main/java/com/example/banchan/data/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/example/banchan/data/repository/HistoryRepositoryImpl.kt
@@ -15,4 +15,8 @@ class HistoryRepositoryImpl @Inject constructor(
         runCatching {
             localDataSource.insertHistoryWithItems(items)
         }
+
+    override suspend fun updateAllHistory() {
+        localDataSource.updateAllHistory()
+    }
 }

--- a/app/src/main/java/com/example/banchan/data/source/HistoryDataSource.kt
+++ b/app/src/main/java/com/example/banchan/data/source/HistoryDataSource.kt
@@ -9,4 +9,5 @@ interface HistoryDataSource {
     fun getHistoryWithItems(): Flow<Result<List<HistoryWithItems>>>
     fun getHistoryWithItemsById(id: Int): Flow<Result<HistoryWithItems>>
     suspend fun insertHistoryWithItems(items: List<HistoryItem>): Result<Unit>
+    suspend fun updateAllHistory()
 }

--- a/app/src/main/java/com/example/banchan/data/source/local/history/History.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/history/History.kt
@@ -9,5 +9,5 @@ data class History(
     @PrimaryKey(autoGenerate = true)
     val id: Long,
     val date: Date = Date(),
-    val remainTime: Int = 20
+    val remainTime: Int = 5
 )

--- a/app/src/main/java/com/example/banchan/data/source/local/history/HistoryDao.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/history/HistoryDao.kt
@@ -1,10 +1,9 @@
 package com.example.banchan.data.source.local.history
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.Query
-import androidx.room.Transaction
+import androidx.room.*
+import com.example.banchan.util.DEFAULT_DELIVERY_TIME
 import kotlinx.coroutines.flow.Flow
+import java.util.*
 
 @Dao
 interface HistoryDao {
@@ -16,6 +15,23 @@ interface HistoryDao {
 
     @Insert
     suspend fun insertHistory(history: History): Long
+
+    @Query("select * from history")
+    suspend fun getAllHistory(): List<History>
+
+    @Update
+    suspend fun updateHistory(history: History)
+
+    @Transaction
+    suspend fun updateAllHistory(time: Int) {
+        val history = getAllHistory()
+        history.forEach {
+            val calTime =
+                DEFAULT_DELIVERY_TIME - ((Date().time - it.date.time) / (1000 * 60)).toInt()
+            val remainTime = if (calTime >= 0) calTime else 0
+            updateHistory(it.copy(remainTime = remainTime))
+        }
+    }
 
     @Insert
     suspend fun insertHistoryItem(vararg historyItem: HistoryItem)

--- a/app/src/main/java/com/example/banchan/data/source/local/history/HistoryLocalDataSource.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/history/HistoryLocalDataSource.kt
@@ -3,6 +3,7 @@ package com.example.banchan.data.source.local.history
 import com.example.banchan.data.source.HistoryDataSource
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -27,6 +28,12 @@ class HistoryLocalDataSource @Inject constructor(
     override suspend fun insertHistoryWithItems(items: List<HistoryItem>) = runCatching {
         withContext(ioDispatcher) {
             historyDao.insertHistoryWithItems(items)
+        }
+    }
+
+    override suspend fun updateAllHistory() {
+        withContext(ioDispatcher) {
+            historyDao.updateAllHistory(1)
         }
     }
 }

--- a/app/src/main/java/com/example/banchan/domain/usecase/GetHistoryByIdUseCase.kt
+++ b/app/src/main/java/com/example/banchan/domain/usecase/GetHistoryByIdUseCase.kt
@@ -1,0 +1,10 @@
+package com.example.banchan.domain.usecase
+
+import com.example.banchan.data.repository.HistoryRepository
+import javax.inject.Inject
+
+class GetHistoryByIdUseCase @Inject constructor(
+    private val historyRepository: HistoryRepository
+) {
+    operator fun invoke(id: Int) = historyRepository.getHistoryWithItemsById(id)
+}

--- a/app/src/main/java/com/example/banchan/domain/usecase/UpdateHistoryUseCase.kt
+++ b/app/src/main/java/com/example/banchan/domain/usecase/UpdateHistoryUseCase.kt
@@ -1,0 +1,10 @@
+package com.example.banchan.domain.usecase
+
+import com.example.banchan.data.repository.HistoryRepository
+import javax.inject.Inject
+
+class UpdateHistoryUseCase @Inject constructor(
+    private val historyRepository: HistoryRepository
+) {
+    suspend operator fun invoke() = historyRepository.updateAllHistory()
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonAdapter.kt
@@ -1,4 +1,4 @@
-package com.example.banchan.presentation.adapter.home
+package com.example.banchan.presentation.adapter.common
 
 import android.view.ViewGroup
 import androidx.annotation.StringRes
@@ -6,6 +6,9 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.banchan.domain.model.ItemModel
+import com.example.banchan.presentation.adapter.home.HomeEmptyViewHolder
+import com.example.banchan.presentation.adapter.home.HomeHeaderViewHolder
+import com.example.banchan.presentation.adapter.home.HomeLoadingViewHolder
 import com.example.banchan.presentation.adapter.main.MediumMenuViewHolder
 import com.example.banchan.presentation.home.maincook.Filter
 

--- a/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonFilterViewViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonFilterViewViewHolder.kt
@@ -1,4 +1,4 @@
-package com.example.banchan.presentation.adapter.home
+package com.example.banchan.presentation.adapter.common
 
 import android.view.LayoutInflater
 import android.view.View

--- a/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonOrderFooterAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonOrderFooterAdapter.kt
@@ -1,0 +1,27 @@
+package com.example.banchan.presentation.adapter.common
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.presentation.ordersuccess.OrderCommonListModel
+
+class CommonOrderFooterAdapter : RecyclerView.Adapter<CommonOrderFooterViewHolder>() {
+    private var footerModel: OrderCommonListModel.Footer? = null
+
+    fun updateFooter(footer: OrderCommonListModel.Footer){
+        footerModel = footer
+        notifyItemChanged(0)
+    }
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): CommonOrderFooterViewHolder = CommonOrderFooterViewHolder.create(parent)
+
+    override fun onBindViewHolder(holder: CommonOrderFooterViewHolder, position: Int) {
+        footerModel?.let { holder.bind(it) }
+    }
+
+    override fun getItemCount(): Int {
+        return 1
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonOrderFooterViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonOrderFooterViewHolder.kt
@@ -1,0 +1,28 @@
+package com.example.banchan.presentation.adapter.common
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.R
+import com.example.banchan.databinding.ItemOrderFooterBinding
+import com.example.banchan.presentation.ordersuccess.OrderCommonListModel
+
+class CommonOrderFooterViewHolder(private val binding: ItemOrderFooterBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+    fun bind(footer: OrderCommonListModel.Footer) {
+        val res = binding.root.resources
+        binding.tvOrderPrice.text = res.getString(R.string.amount_format, footer.orderPrice)
+        binding.tvDeliveryFee.text = res.getString(R.string.amount_format, footer.deliveryFee)
+        binding.tvItemTotal.text = res.getString(R.string.amount_format, footer.totalPrice)
+    }
+
+    companion object {
+        fun create(parent: ViewGroup) = CommonOrderFooterViewHolder(
+            ItemOrderFooterBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonOrderHeaderAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonOrderHeaderAdapter.kt
@@ -1,0 +1,27 @@
+package com.example.banchan.presentation.adapter.common
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.presentation.ordersuccess.OrderCommonListModel
+
+class CommonOrderHeaderAdapter : RecyclerView.Adapter<CommonOrderHeaderViewHolder>() {
+    private var headerModel: OrderCommonListModel.Header? = null
+
+    fun updateHeader(header: OrderCommonListModel.Header) {
+        headerModel = header
+        notifyItemChanged(0)
+    }
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): CommonOrderHeaderViewHolder = CommonOrderHeaderViewHolder.create(parent)
+
+    override fun onBindViewHolder(holder: CommonOrderHeaderViewHolder, position: Int) {
+        headerModel?.let { holder.bind(it) }
+    }
+
+    override fun getItemCount(): Int {
+        return 1
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonOrderHeaderViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonOrderHeaderViewHolder.kt
@@ -1,0 +1,24 @@
+package com.example.banchan.presentation.adapter.common
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.databinding.ItemOrderHeaderBinding
+import com.example.banchan.presentation.ordersuccess.OrderCommonListModel
+
+class CommonOrderHeaderViewHolder(private val binding: ItemOrderHeaderBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+    fun bind(header: OrderCommonListModel.Header) {
+        binding.item = header
+    }
+
+    companion object {
+        fun create(parent: ViewGroup) = CommonOrderHeaderViewHolder(
+            ItemOrderHeaderBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/ordersuccess/OrderSuccessItemAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/ordersuccess/OrderSuccessItemAdapter.kt
@@ -1,0 +1,34 @@
+package com.example.banchan.presentation.adapter.ordersuccess
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.example.banchan.presentation.ordersuccess.OrderSuccessListModel
+
+class OrderSuccessItemAdapter :
+    ListAdapter<OrderSuccessListModel.Item, OrderSuccessItemViewHolder>(DiffCallback()) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OrderSuccessItemViewHolder =
+        OrderSuccessItemViewHolder.create(parent)
+
+    override fun onBindViewHolder(holder: OrderSuccessItemViewHolder, position: Int) {
+        holder.bind(getItem(position).historyItem)
+    }
+
+    companion object {
+        class DiffCallback : DiffUtil.ItemCallback<OrderSuccessListModel.Item>() {
+            override fun areItemsTheSame(
+                oldItem: OrderSuccessListModel.Item,
+                newItem: OrderSuccessListModel.Item
+            ): Boolean {
+                return oldItem.historyItem.itemId == newItem.historyItem.itemId
+            }
+
+            override fun areContentsTheSame(
+                oldItem: OrderSuccessListModel.Item,
+                newItem: OrderSuccessListModel.Item
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/ordersuccess/OrderSuccessItemViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/ordersuccess/OrderSuccessItemViewHolder.kt
@@ -1,0 +1,25 @@
+package com.example.banchan.presentation.adapter.ordersuccess
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.data.source.local.history.HistoryItem
+import com.example.banchan.databinding.ItemOrderSuccessBinding
+
+class OrderSuccessItemViewHolder(
+    private val binding: ItemOrderSuccessBinding
+) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(historyItem: HistoryItem) {
+        binding.item = historyItem
+    }
+
+    companion object {
+        fun create(parent: ViewGroup) = OrderSuccessItemViewHolder(
+            ItemOrderSuccessBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/home/side/SideFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/side/SideFragment.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentSoupBinding
-import com.example.banchan.presentation.adapter.home.CommonAdapter
-import com.example.banchan.presentation.adapter.home.CommonItemListModel
+import com.example.banchan.presentation.adapter.common.CommonAdapter
+import com.example.banchan.presentation.adapter.common.CommonItemListModel
 import com.example.banchan.presentation.adapter.main.GridSpacingItemDecorator
 import com.example.banchan.presentation.home.HomeTabFragment
 import com.example.banchan.util.dimen.dpToPx

--- a/app/src/main/java/com/example/banchan/presentation/home/side/SideViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/side/SideViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.banchan.R
 import com.example.banchan.domain.usecase.GetSideDishesUseCase
-import com.example.banchan.presentation.adapter.home.CommonItemListModel
+import com.example.banchan.presentation.adapter.common.CommonItemListModel
 import com.example.banchan.presentation.home.maincook.Filter
 import com.example.banchan.util.ext.toNum
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/example/banchan/presentation/home/soup/SoupFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/soup/SoupFragment.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentSoupBinding
-import com.example.banchan.presentation.adapter.home.CommonAdapter
-import com.example.banchan.presentation.adapter.home.CommonItemListModel
+import com.example.banchan.presentation.adapter.common.CommonAdapter
+import com.example.banchan.presentation.adapter.common.CommonItemListModel
 import com.example.banchan.presentation.adapter.main.GridSpacingItemDecorator
 import com.example.banchan.presentation.home.HomeTabFragment
 import com.example.banchan.util.dimen.dpToPx

--- a/app/src/main/java/com/example/banchan/presentation/home/soup/SoupViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/soup/SoupViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.banchan.R
 import com.example.banchan.domain.usecase.GetSoupDishesUseCase
-import com.example.banchan.presentation.adapter.home.CommonItemListModel
+import com.example.banchan.presentation.adapter.common.CommonItemListModel
 import com.example.banchan.presentation.home.maincook.Filter
 import com.example.banchan.util.ext.toNum
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
@@ -38,7 +38,7 @@ class MainActivity : AppCompatActivity() {
                     if (targetFragment == null) {
                         // 추후 다른 Fragment 생성 후 수정 예정
                         val fragment = when (it) {
-                            FragmentType.Home -> OrderSuccessFragment()
+                            FragmentType.Home -> HomeFragment()
                             FragmentType.Basket -> BasketFragment()
                             FragmentType.OrderDetail -> HomeFragment()
                             FragmentType.ProductDetail -> ProductDetailFragment()

--- a/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
@@ -11,6 +11,7 @@ import com.example.banchan.R
 import com.example.banchan.databinding.ActivityMainBinding
 import com.example.banchan.presentation.basket.BasketFragment
 import com.example.banchan.presentation.home.HomeFragment
+import com.example.banchan.presentation.ordersuccess.OrderSuccessFragment
 import com.example.banchan.presentation.productdetail.ProductDetailFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -37,7 +38,7 @@ class MainActivity : AppCompatActivity() {
                     if (targetFragment == null) {
                         // 추후 다른 Fragment 생성 후 수정 예정
                         val fragment = when (it) {
-                            FragmentType.Home -> HomeFragment()
+                            FragmentType.Home -> OrderSuccessFragment()
                             FragmentType.Basket -> BasketFragment()
                             FragmentType.OrderDetail -> HomeFragment()
                             FragmentType.ProductDetail -> ProductDetailFragment()

--- a/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
@@ -10,8 +10,8 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.example.banchan.R
 import com.example.banchan.databinding.ActivityMainBinding
 import com.example.banchan.presentation.basket.BasketFragment
-import com.example.banchan.presentation.productdetail.ProductDetailFragment
 import com.example.banchan.presentation.home.HomeFragment
+import com.example.banchan.presentation.productdetail.ProductDetailFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -56,7 +56,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onBackPressed() {
         super.onBackPressed()
-        when(supportFragmentManager.findFragmentById(R.id.layout_main_container)?.tag) {
+        when (supportFragmentManager.findFragmentById(R.id.layout_main_container)?.tag) {
             FragmentType.Home.tag -> mainViewModel.setCurrentFragment(FragmentType.Home)
             FragmentType.Basket.tag -> mainViewModel.setCurrentFragment(FragmentType.Basket)
             FragmentType.OrderDetail.tag -> mainViewModel.setCurrentFragment(FragmentType.OrderDetail)

--- a/app/src/main/java/com/example/banchan/presentation/ordersuccess/OrderSuccessFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/ordersuccess/OrderSuccessFragment.kt
@@ -1,0 +1,65 @@
+package com.example.banchan.presentation.ordersuccess
+
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.ConcatAdapter
+import com.example.banchan.R
+import com.example.banchan.databinding.FragmentOrderSuccessBinding
+import com.example.banchan.presentation.adapter.common.CommonOrderFooterAdapter
+import com.example.banchan.presentation.adapter.common.CommonOrderHeaderAdapter
+import com.example.banchan.presentation.adapter.ordersuccess.OrderSuccessItemAdapter
+import com.example.banchan.presentation.base.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class OrderSuccessFragment :
+    BaseFragment<FragmentOrderSuccessBinding>(R.layout.fragment_order_success) {
+    val viewModel by viewModels<OrderSuccessViewModel>()
+    private val headerAdapter = CommonOrderHeaderAdapter()
+    private val itemAdapter = OrderSuccessItemAdapter()
+    private val footerAdapter = CommonOrderFooterAdapter()
+
+    override fun initViews() {
+        binding.rvOrderSuccess.apply {
+            itemAnimator = null
+            adapter = ConcatAdapter(
+                headerAdapter,
+                itemAdapter,
+                footerAdapter
+            )
+        }
+    }
+
+    override fun observe() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.headerUiState.collect {
+                        it?.let {
+                            headerAdapter.updateHeader(it)
+                        }
+                    }
+                }
+                launch {
+                    viewModel.itemsUiState.collect {
+                        it?.let {
+                            itemAdapter.submitList(it)
+                        }
+                    }
+                }
+                launch {
+                    launch {
+                        viewModel.footerUiState.collect {
+                            it?.let {
+                                footerAdapter.updateFooter(it)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/ordersuccess/OrderSuccessFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/ordersuccess/OrderSuccessFragment.kt
@@ -31,6 +31,10 @@ class OrderSuccessFragment :
                 footerAdapter
             )
         }
+
+        binding.toolbarRefresh.setOnClickListener {
+            viewModel.refresh()
+        }
     }
 
     override fun observe() {

--- a/app/src/main/java/com/example/banchan/presentation/ordersuccess/OrderSuccessViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/ordersuccess/OrderSuccessViewModel.kt
@@ -1,0 +1,64 @@
+package com.example.banchan.presentation.ordersuccess
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.banchan.data.source.local.history.HistoryItem
+import com.example.banchan.domain.usecase.GetHistoryByIdUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class OrderSuccessViewModel @Inject constructor(
+    private val getHistoryByIdUseCase: GetHistoryByIdUseCase
+) : ViewModel() {
+    val history = getHistoryByIdUseCase(1)
+    val headerUiState = history.map { result ->
+        result.getOrNull()?.let {
+            OrderCommonListModel.Header(
+                time = it.history.remainTime,
+                count = it.items.size
+            )
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = OrderCommonListModel.Header(0, 0)
+    )
+    val itemsUiState = history.map { result ->
+        result.getOrNull()?.let {
+            it.items.map { item -> OrderSuccessListModel.Item(item) }
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = listOf()
+    )
+    val footerUiState = history.map { result ->
+        result.getOrNull()?.let {
+            val defaultDeliveryFee = 2500
+            val orderPrice = it.items.sumOf { item -> item.originPrice * item.count }
+            OrderCommonListModel.Footer(
+                orderPrice = orderPrice,
+                deliveryFee = defaultDeliveryFee,
+                totalPrice = orderPrice + defaultDeliveryFee
+            )
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = OrderCommonListModel.Footer(0, 0, 0)
+    )
+}
+
+sealed interface OrderCommonListModel {
+    data class Header(val time: Int, val count: Int) : OrderCommonListModel
+    data class Footer(val orderPrice: Int, val deliveryFee: Int, val totalPrice: Int) :
+        OrderCommonListModel
+}
+
+sealed interface OrderSuccessListModel {
+    data class Item(val historyItem: HistoryItem) : OrderSuccessListModel
+}

--- a/app/src/main/java/com/example/banchan/util/Constant.kt
+++ b/app/src/main/java/com/example/banchan/util/Constant.kt
@@ -1,0 +1,4 @@
+package com.example.banchan.util
+
+const val DEFAULT_DELIVERY_TIME = 20
+const val DEFAULT_DELIVERY_FEE = 2500

--- a/app/src/main/res/layout/fragment_order_success.xml
+++ b/app/src/main/res/layout/fragment_order_success.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/greyscale_surface">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_order_success"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_order_success.xml
+++ b/app/src/main/res/layout/fragment_order_success.xml
@@ -11,12 +11,34 @@
         android:layout_height="match_parent"
         android:background="@color/greyscale_surface">
 
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar_order_success"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/primary_main"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/toolbar_back"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_arrowleft" />
+
+            <ImageView
+                android:id="@+id/toolbar_refresh"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:layout_marginEnd="18dp"
+                android:src="@drawable/ic_reload" />
+        </androidx.appcompat.widget.Toolbar>
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_order_success"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/toolbar_order_success" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_menu.xml
+++ b/app/src/main/res/layout/item_menu.xml
@@ -52,7 +52,7 @@
             tools:text="오리주물럭" />
 
         <TextView
-            android:id="@+id/tv_content"
+            android:id="@+id/tv_item_count"
             style="@style/tv_normal_12.GreyDefault"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -73,14 +73,14 @@
             android:layout_marginEnd="4dp"
             android:text="@{item.discountPercent}"
             android:visibility="@{item.discountPercent == null ? View.GONE : View.VISIBLE}"
-            app:layout_constraintEnd_toStartOf="@id/tv_display_price"
+            app:layout_constraintEnd_toStartOf="@id/tv_item_total"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/tv_display_price"
+            app:layout_constraintTop_toTopOf="@id/tv_item_total"
             tools:text="20%" />
 
         <TextView
-            android:id="@+id/tv_display_price"
+            android:id="@+id/tv_item_total"
             style="@style/tv_normal_14.Black"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -90,7 +90,7 @@
             android:text="@{item.discountPercent == null ? item.originPrice : item.discountPrice}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/tv_discount"
-            app:layout_constraintTop_toBottomOf="@id/tv_content"
+            app:layout_constraintTop_toBottomOf="@id/tv_item_count"
             tools:text="1234원" />
 
         <TextView
@@ -103,7 +103,7 @@
             android:text="@{item.originPrice}"
             android:visibility="@{item.discountPercent == null ? View.GONE : View.VISIBLE}"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_display_price"
+            app:layout_constraintTop_toBottomOf="@id/tv_item_total"
             tools:text="1234원" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_menu_large.xml
+++ b/app/src/main/res/layout/item_menu_large.xml
@@ -43,19 +43,19 @@
             android:layout_marginStart="16dp"
             android:layout_marginBottom="8dp"
             android:text="@{item.title}"
-            app:layout_constraintBottom_toTopOf="@id/tv_content"
+            app:layout_constraintBottom_toTopOf="@id/tv_item_count"
             app:layout_constraintStart_toEndOf="@id/iv_banchan"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_chainStyle="packed"
             tools:text="오리주물럭" />
 
         <TextView
-            android:id="@+id/tv_content"
+            android:id="@+id/tv_item_count"
             style="@style/tv_normal_12.GreyDefault"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@{item.description}"
-            app:layout_constraintBottom_toTopOf="@id/tv_display_price"
+            app:layout_constraintBottom_toTopOf="@id/tv_item_total"
             app:layout_constraintStart_toStartOf="@id/tv_title"
             app:layout_constraintTop_toBottomOf="@id/tv_title"
             tools:text="감칠맛 나는 양념" />
@@ -68,14 +68,14 @@
             android:layout_marginEnd="4dp"
             android:text="@{item.discountPercent}"
             android:visibility="@{item.discountPercent == null ? View.GONE : View.VISIBLE}"
-            app:layout_constraintEnd_toStartOf="@id/tv_display_price"
+            app:layout_constraintEnd_toStartOf="@id/tv_item_total"
             app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toStartOf="@id/tv_content"
-            app:layout_constraintTop_toTopOf="@id/tv_display_price"
+            app:layout_constraintStart_toStartOf="@id/tv_item_count"
+            app:layout_constraintTop_toTopOf="@id/tv_item_total"
             tools:text="20%" />
 
         <TextView
-            android:id="@+id/tv_display_price"
+            android:id="@+id/tv_item_total"
             style="@style/tv_normal_14.Black"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -84,7 +84,7 @@
             app:layout_constraintBottom_toTopOf="@id/tv_origin_price"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/tv_discount"
-            app:layout_constraintTop_toBottomOf="@id/tv_content"
+            app:layout_constraintTop_toBottomOf="@id/tv_item_count"
             tools:text="1234원" />
 
         <TextView
@@ -97,8 +97,8 @@
             android:text="@{item.originPrice}"
             android:visibility="@{item.discountPercent == null ? View.GONE : View.VISIBLE}"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="@id/tv_content"
-            app:layout_constraintTop_toBottomOf="@id/tv_display_price"
+            app:layout_constraintStart_toStartOf="@id/tv_item_count"
+            app:layout_constraintTop_toBottomOf="@id/tv_item_total"
             tools:text="1234원" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_menu_medium.xml
+++ b/app/src/main/res/layout/item_menu_medium.xml
@@ -47,7 +47,7 @@
             tools:text="오리주물럭" />
 
         <TextView
-            android:id="@+id/tv_content"
+            android:id="@+id/tv_item_count"
             style="@style/tv_normal_12.GreyDefault"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -65,14 +65,14 @@
             android:layout_marginEnd="4dp"
             android:text="@{item.discountPercent}"
             android:visibility="@{item.discountPercent == null ? View.GONE : View.VISIBLE}"
-            app:layout_constraintEnd_toStartOf="@id/tv_display_price"
+            app:layout_constraintEnd_toStartOf="@id/tv_item_total"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/tv_display_price"
+            app:layout_constraintTop_toTopOf="@id/tv_item_total"
             tools:text="20%" />
 
         <TextView
-            android:id="@+id/tv_display_price"
+            android:id="@+id/tv_item_total"
             style="@style/tv_normal_14.Black"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -80,7 +80,7 @@
             android:text="@{item.discountPercent == null ? item.originPrice : item.discountPrice}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/tv_discount"
-            app:layout_constraintTop_toBottomOf="@id/tv_content"
+            app:layout_constraintTop_toBottomOf="@id/tv_item_count"
             tools:text="1234원" />
 
         <TextView
@@ -93,7 +93,7 @@
             android:text="@{item.originPrice}"
             android:visibility="@{item.discountPercent == null ? View.GONE : View.VISIBLE}"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_display_price"
+            app:layout_constraintTop_toBottomOf="@id/tv_item_total"
             tools:text="1234원" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_order_footer.xml
+++ b/app/src/main/res/layout/item_order_footer.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/greyscale_surface">
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/greyscale_line"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_order_price_description"
+        style="@style/tv_normal_14.GreyDefault"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="104dp"
+        android:layout_marginTop="24dp"
+        android:text="@string/order_price"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/divider" />
+
+    <TextView
+        android:id="@+id/tv_order_price"
+        style="@style/tv_normal_14.GreyDefault"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:gravity="end"
+        app:layout_constraintBaseline_toBaselineOf="@+id/tv_order_price_description"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/tv_order_price_description"
+        tools:text="15000원" />
+
+    <TextView
+        android:id="@+id/tv_delivery_fee_description"
+        style="@style/tv_normal_14.GreyDefault"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="104dp"
+        android:text="@string/delivery_fee"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_order_price_description" />
+
+    <TextView
+        android:id="@+id/tv_delivery_fee"
+        style="@style/tv_normal_14.GreyDefault"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:gravity="end"
+        app:layout_constraintBaseline_toBaselineOf="@+id/tv_delivery_fee_description"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/tv_delivery_fee_description"
+        tools:text="15000원" />
+
+    <View
+        android:id="@+id/divider_price"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_marginTop="8dp"
+        android:background="@color/greyscale_line"
+        app:layout_constraintEnd_toEndOf="@id/tv_delivery_fee"
+        app:layout_constraintStart_toStartOf="@id/tv_delivery_fee_description"
+        app:layout_constraintTop_toBottomOf="@id/tv_delivery_fee_description" />
+
+    <TextView
+        style="@style/tv_normal_14.Black"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/total_price"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="@id/divider_price"
+        app:layout_constraintTop_toBottomOf="@id/divider_price" />
+
+    <TextView
+        android:id="@+id/tv_item_total"
+        style="@style/tv_normal_14.Black"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="@id/divider_price"
+        app:layout_constraintTop_toBottomOf="@id/divider_price"
+        tools:text="777원" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_order_header.xml
+++ b/app/src/main/res/layout/item_order_header.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <import type="android.view.View" />
+
+        <variable
+            name="item"
+            type="com.example.banchan.presentation.ordersuccess.OrderCommonListModel.Header" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="22dp"
+        android:background="@color/greyscale_surface">
+
+        <TextView
+            android:id="@+id/tv_order"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:text="@{item.time != 0 ? @string/order_success : @string/delivery_success}"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_remain_time_description"
+            style="@style/tv_normal_14.GreyDefault"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/remain_delivery_time"
+            android:visibility="@{item.time != 0 ? View.VISIBLE : View.GONE}"
+            app:layout_constraintStart_toStartOf="@id/tv_order"
+            app:layout_constraintTop_toBottomOf="@id/tv_order" />
+
+        <TextView
+            android:id="@+id/tv_remain_time"
+            style="@style/tv_normal_14.Black"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@{@string/minute_format(item.time)}"
+            android:textStyle="bold"
+            android:visibility="@{item.time != 0 ? View.VISIBLE : View.GONE}"
+            app:layout_constraintBaseline_toBaselineOf="@+id/tv_remain_time_description"
+            app:layout_constraintStart_toEndOf="@id/tv_remain_time_description"
+            tools:text="20분" />
+
+        <TextView
+            android:id="@+id/tv_order_description"
+            style="@style/tv_normal_14.GreyDefault"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/order_menu"
+            app:layout_constraintStart_toStartOf="@id/tv_remain_time_description"
+            app:layout_constraintTop_toBottomOf="@id/tv_remain_time_description" />
+
+        <TextView
+            android:id="@+id/tv_order_count"
+            style="@style/tv_normal_14.Black"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@{@string/total_count_format(item.count)}"
+            android:textStyle="bold"
+            app:layout_constraintBaseline_toBaselineOf="@+id/tv_order_description"
+            app:layout_constraintStart_toEndOf="@id/tv_order_description"
+            tools:text="총 2개" />
+
+        <View
+            android:id="@+id/divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="22dp"
+            android:background="@color/greyscale_line"
+            app:layout_constraintTop_toBottomOf="@id/tv_order_description" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_order_success.xml
+++ b/app/src/main/res/layout/item_order_success.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="item"
+            type="com.example.banchan.data.source.local.history.HistoryItem" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:background="@color/white">
+
+        <ImageView
+            android:id="@+id/iv_banchan"
+            imageUrl="@{item.imageUrl}"
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@tools:sample/avatars" />
+
+        <TextView
+            android:id="@+id/tv_title"
+            style="@style/tv_normal_14.Black"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginBottom="8dp"
+            android:text="@{item.name}"
+            app:layout_constraintBottom_toTopOf="@id/tv_item_count"
+            app:layout_constraintStart_toEndOf="@id/iv_banchan"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed"
+            tools:text="오리주물럭" />
+
+        <TextView
+            android:id="@+id/tv_item_count"
+            style="@style/tv_normal_14.Black"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{@string/count_format(item.count)}"
+            app:layout_constraintBottom_toTopOf="@id/tv_item_total"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_title"
+            tools:text="1개" />
+
+        <TextView
+            android:id="@+id/tv_item_total"
+            style="@style/tv_normal_14.Black"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@{@string/amount_format(item.originPrice * item.count)}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tv_item_count"
+            app:layout_constraintTop_toBottomOf="@id/tv_item_count"
+            tools:text="6000원" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,13 @@
     <string name="home_empty">주문 할 수 있는 음식이 없어요.</string>
 
     <string name="total_format">총 %d개 상품</string>
+    <string name="total_price">총 결제 금액</string>
+    <string name="delivery_fee">배송료</string>
+    <string name="order_price">상품 주문 금액</string>
+    <string name="order_success">주문이 접수되었습니다.</string>
+    <string name="delivery_success">배송이 완료되었습니다.</string>
+    <string name="remain_delivery_time">배송까지 남은 시간</string>
+    <string name="order_menu">주문한 상품</string>
 
     <string name="bottom_sheet_basket_title">장바구니 담기</string>
     <string name="bottom_sheet_basket_cancel">취소</string>
@@ -30,6 +37,11 @@
         <item>뜨끈한 국물요리</item>
         <item>정갈한 밑반찬</item>
     </string-array>
+
+    <string name="count_format">%d개</string>
+    <string name="total_count_format">총 %d 개</string>
+    <string name="minute_format">%d분</string>
+    <string name="amount_format">%d원</string>
 
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,4 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <!-- Base application theme. -->
     <style name="Theme.Banchan" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
@@ -38,6 +38,11 @@
         <item name="android:textColor">@color/greyscale_default</item>
     </style>
 
+    <style name="tv_normal_14.GreyDefault">
+        <item name="android:textColor">@color/greyscale_default</item>
+        <item name="android:textSize">14sp</item>
+    </style>
+    
     <style name="AppBottomSheetDialogTheme"
         parent="Theme.Design.Light.BottomSheetDialog">
         <item name="bottomSheetStyle">@style/AppModalStyle</item>


### PR DESCRIPTION
## Summary
주문 상태 화면 UI 및 로직 일부 구현

## Main Changes
- 주문 상태 화면 UI 구현
- 로직 일부 구현

아래 화면은 테스트용으로 빠르게 카운트다운한 예시
현재 서비스에서 1분마다 카운트다운하는식으로구현했는데,
좀 더 고민해보고 바꿀수도있을거같습니다!

![KakaoTalk_Video_2022-08-16-23-44-39](https://user-images.githubusercontent.com/54823396/184908871-641126ce-13fe-4dc7-9c60-947e4c4b8bfa.gif)

Closes #46 