### PR TITLE
[FEAT] 최근 본 상품 목록 구현 #52

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -39,6 +39,7 @@
         <entry key="app/src/main/res/layout/item_home_header.xml" value="0.33410672853828305" />
         <entry key="app/src/main/res/layout/item_home_loading.xml" value="0.375" />
         <entry key="app/src/main/res/layout/item_menu.xml" value="0.33" />
+        <entry key="app/src/main/res/layout/item_menu_large.xml" value="0.1" />
         <entry key="app/src/main/res/layout/item_menu_medium.xml" value="0.12708333333333333" />
         <entry key="app/src/main/res/layout/item_order_header.xml" value="0.10507246376811594" />
         <entry key="app/src/main/res/layout/item_order_success.xml" value="0.24414715719063546" />

--- a/app/src/main/java/com/example/banchan/data/response/best/Item.kt
+++ b/app/src/main/java/com/example/banchan/data/response/best/Item.kt
@@ -21,15 +21,15 @@ data class Item(
     val sPrice: String,
     val title: String
 ) {
-    fun toItemModel() : ItemModel {
+    fun toItemModel(): ItemModel {
         return ItemModel(
             title = title,
             description = description,
             detailHash = detailHash,
             image = image,
             originPrice = nPrice ?: sPrice,
-            discountPrice = if(nPrice!=null) sPrice else null,
-            discountPercent = if(nPrice!=null) "${calculationPercent(nPrice, sPrice)}%" else null
+            discountPrice = if (nPrice != null) sPrice else null,
+            discountPercent = if (nPrice != null) "${calculationPercent(nPrice, sPrice)}%" else null
         )
     }
 

--- a/app/src/main/java/com/example/banchan/data/response/detail/DetailResponse.kt
+++ b/app/src/main/java/com/example/banchan/data/response/detail/DetailResponse.kt
@@ -3,9 +3,12 @@ package com.example.banchan.data.response.detail
 import com.example.banchan.domain.model.BasketModel
 import com.example.banchan.domain.model.ProductDetailModel
 import com.example.banchan.domain.model.RecentlyProductItemModel
+import com.example.banchan.domain.model.RecentlyProductModel
 import com.example.banchan.util.calcul.calculationPercent
 import com.example.banchan.util.ext.toNum
+import com.example.banchan.util.ext.toTimeFormat
 import kotlinx.serialization.Serializable
+import java.util.*
 
 @Serializable
 data class DetailResponse(
@@ -19,7 +22,10 @@ data class DetailResponse(
             point = data.point.toNum(),
             originPrice = data.prices[0].toNum(),
             discountPrice = if (data.prices.size == 1) null else data.prices[1].toNum(),
-            discountPercent = if (data.prices.size == 1) null else calculationPercent(data.prices[0],data.prices[1]),
+            discountPercent = if (data.prices.size == 1) null else calculationPercent(
+                data.prices[0],
+                data.prices[1]
+            ),
             description = data.productDescription,
             thumbImages = data.thumbImages,
             detailSection = data.detailSection,
@@ -47,6 +53,25 @@ data class DetailResponse(
             viewedTime = time,
             originPrice = data.prices[0].toNum(),
             discountPrice = if (data.prices.size == 1) null else data.prices[1].toNum(),
+        )
+    }
+
+    fun toRecentlyModel(date: Date, name: String, isCartAdded: Boolean): RecentlyProductModel {
+        return RecentlyProductModel(
+            title = name,
+            detailHash = hash,
+            originPrice = data.prices[0],
+            discountPrice = if (data.prices.size == 1) null else data.prices[1],
+            discountPercent = if (data.prices.size == 1) null else "${
+                calculationPercent(
+                    data.prices[0],
+                    data.prices[1]
+                )
+            }%",
+            time = ((Date().time - date.time) / 1000).toTimeFormat(),
+            description = data.productDescription,
+            image = data.thumbImages[0],
+            isCartAdded = isCartAdded
         )
     }
 }

--- a/app/src/main/java/com/example/banchan/domain/model/RecentlyProductModel.kt
+++ b/app/src/main/java/com/example/banchan/domain/model/RecentlyProductModel.kt
@@ -1,0 +1,13 @@
+package com.example.banchan.domain.model
+
+data class RecentlyProductModel(
+    val description: String,
+    val detailHash: String,
+    val image: String,
+    val discountPercent: String?,
+    val discountPrice: String? = null,
+    val originPrice: String,
+    val title: String,
+    val time: String,
+    val isCartAdded: Boolean = false,
+)

--- a/app/src/main/java/com/example/banchan/domain/usecase/recently/GetRecentProductUseCase.kt
+++ b/app/src/main/java/com/example/banchan/domain/usecase/recently/GetRecentProductUseCase.kt
@@ -1,0 +1,39 @@
+package com.example.banchan.domain.usecase.recently
+
+import com.example.banchan.data.repository.RecentlyProductRepository
+import com.example.banchan.domain.model.RecentlyProductModel
+import com.example.banchan.domain.usecase.basket.GetBasketItemUseCase
+import com.example.banchan.domain.usecase.detail.GetProductDetailUseCase
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.*
+import javax.inject.Inject
+
+class GetRecentProductUseCase @Inject constructor(
+    private val getBasketItemUseCase: GetBasketItemUseCase,
+    private val getProductDetailUseCase: GetProductDetailUseCase,
+    private val recentlyProductRepository: RecentlyProductRepository
+) {
+    @OptIn(FlowPreview::class)
+    operator fun invoke() = flow {
+        combine(
+            recentlyProductRepository.getRecentlyProducts(),
+            getBasketItemUseCase()
+        ) { products, basketList ->
+            if (products.isSuccess && basketList.isSuccess) {
+                products.getOrNull()?.asFlow()?.flatMapMerge {
+                    flow {
+                        getProductDetailUseCase(it.hash).getOrNull()?.let { response ->
+                            emit(response.toRecentlyModel(
+                                it.recentlyTime,
+                                it.name,
+                                it.hash in basketList.getOrDefault(listOf()).map { it.hash }
+                            ))
+                        }
+                    }
+                }?.scan(emptyList<RecentlyProductModel>()) { i1, i2 -> i1 + i2 }?.onEach {
+                    emit(it.sortedBy { it.time })
+                }?.collect()
+            }
+        }.collect()
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonGridSpacingItemDecorator.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/common/CommonGridSpacingItemDecorator.kt
@@ -1,0 +1,30 @@
+package com.example.banchan.presentation.adapter.common
+
+import android.graphics.Rect
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+class CommonGridSpacingItemDecorator(private val padding: Int) : RecyclerView.ItemDecoration() {
+    override fun getItemOffsets(
+        outRect: Rect,
+        view: View,
+        parent: RecyclerView,
+        state: RecyclerView.State
+    ) {
+        super.getItemOffsets(outRect, view, parent, state)
+
+        val position = parent.getChildAdapterPosition(view)
+        val col = position % 2
+
+        outRect.top = padding
+        outRect.bottom = padding
+
+        if (col == 0) {
+            outRect.left = padding
+            outRect.right = padding / 2
+        } else {
+            outRect.left = padding / 2
+            outRect.right = padding
+        }
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/recentlyproduct/RecentlyProductAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/recentlyproduct/RecentlyProductAdapter.kt
@@ -1,0 +1,37 @@
+package com.example.banchan.presentation.adapter.recentlyproduct
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.example.banchan.domain.model.RecentlyProductModel
+
+class RecentlyProductAdapter(
+    private val cartClick: (RecentlyProductModel) -> Unit,
+    private val productClick: (RecentlyProductModel) -> Unit
+) :
+    ListAdapter<RecentlyProductModel, RecentlyProductViewHolder>(DiffCallback()) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecentlyProductViewHolder =
+        RecentlyProductViewHolder.create(parent)
+
+    override fun onBindViewHolder(holder: RecentlyProductViewHolder, position: Int) {
+        holder.bind(getItem(position), cartClick, productClick)
+    }
+
+    companion object {
+        class DiffCallback : DiffUtil.ItemCallback<RecentlyProductModel>() {
+            override fun areItemsTheSame(
+                oldItem: RecentlyProductModel,
+                newItem: RecentlyProductModel
+            ): Boolean {
+                return oldItem.detailHash == newItem.detailHash
+            }
+
+            override fun areContentsTheSame(
+                oldItem: RecentlyProductModel,
+                newItem: RecentlyProductModel
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/recentlyproduct/RecentlyProductViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/recentlyproduct/RecentlyProductViewHolder.kt
@@ -1,0 +1,29 @@
+package com.example.banchan.presentation.adapter.recentlyproduct
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.banchan.databinding.ItemRecentBinding
+import com.example.banchan.domain.model.RecentlyProductModel
+
+class RecentlyProductViewHolder(
+    private val binding: ItemRecentBinding
+) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(
+        item: RecentlyProductModel,
+        cartClick: (RecentlyProductModel) -> Unit,
+        productClick: (RecentlyProductModel) -> Unit
+    ) {
+        binding.item = item
+    }
+
+    companion object {
+        fun create(parent: ViewGroup) = RecentlyProductViewHolder(
+            ItemRecentBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/banchan/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/HomeFragment.kt
@@ -6,8 +6,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentHomeBinding
-import com.example.banchan.presentation.base.BaseFragment
 import com.example.banchan.presentation.adapter.home.HomeViewPagerAdapter
+import com.example.banchan.presentation.base.BaseFragment
 import com.example.banchan.presentation.main.BasketViewModel
 import com.example.banchan.util.ext.toast
 import com.google.android.material.tabs.TabLayoutMediator
@@ -36,7 +36,8 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     }
 
     private fun initViewPager() {
-        val adapter = HomeViewPagerAdapter(this, resources.getStringArray(R.array.home_tab_title_array))
+        val adapter =
+            HomeViewPagerAdapter(this, resources.getStringArray(R.array.home_tab_title_array))
         binding.vpHome.adapter = adapter
         TabLayoutMediator(binding.tlHome, binding.vpHome) { tab, position ->
             tab.text = adapter.homeTabTitleArray[position]

--- a/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
@@ -13,6 +13,7 @@ import com.example.banchan.presentation.basket.BasketFragment
 import com.example.banchan.presentation.home.HomeFragment
 import com.example.banchan.presentation.ordersuccess.OrderSuccessFragment
 import com.example.banchan.presentation.productdetail.ProductDetailFragment
+import com.example.banchan.presentation.recentlyproduct.RecentlyProductFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -42,7 +43,7 @@ class MainActivity : AppCompatActivity() {
                             FragmentType.Basket -> BasketFragment()
                             FragmentType.OrderDetail -> HomeFragment()
                             FragmentType.ProductDetail -> ProductDetailFragment()
-                            FragmentType.RecentlyViewedProduct -> HomeFragment()
+                            FragmentType.RecentlyViewedProduct -> RecentlyProductFragment()
                         }
                         supportFragmentManager.commit {
                             setReorderingAllowed(true)

--- a/app/src/main/java/com/example/banchan/presentation/recentlyproduct/RecentlyProductFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/recentlyproduct/RecentlyProductFragment.kt
@@ -1,14 +1,45 @@
 package com.example.banchan.presentation.recentlyproduct
 
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentRecentlyProductBinding
+import com.example.banchan.presentation.adapter.common.CommonGridSpacingItemDecorator
+import com.example.banchan.presentation.adapter.recentlyproduct.RecentlyProductAdapter
 import com.example.banchan.presentation.base.BaseFragment
+import com.example.banchan.util.dimen.dpToPx
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class RecentlyProductFragment :
     BaseFragment<FragmentRecentlyProductBinding>(R.layout.fragment_recently_product) {
+    private val viewModel by viewModels<RecentlyProductViewModel>()
+    private val recentlyProductAdapter by lazy {
+        RecentlyProductAdapter({}, {})
+    }
+
     override fun initViews() {
+        binding.rvRecentlyProduct.apply {
+            adapter = recentlyProductAdapter
+            itemAnimator = null
+            addItemDecoration(CommonGridSpacingItemDecorator(dpToPx(requireActivity(), 16)))
+        }
+
+        binding.toolbarBack.setOnClickListener {
+            parentFragmentManager.popBackStack()
+        }
     }
 
     override fun observe() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.items.collect {
+                    recentlyProductAdapter.submitList(it)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/banchan/presentation/recentlyproduct/RecentlyProductViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/recentlyproduct/RecentlyProductViewModel.kt
@@ -1,0 +1,13 @@
+package com.example.banchan.presentation.recentlyproduct
+
+import androidx.lifecycle.ViewModel
+import com.example.banchan.domain.usecase.recently.GetRecentProductUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class RecentlyProductViewModel @Inject constructor(
+    private val getRecentProductUseCase: GetRecentProductUseCase
+) : ViewModel() {
+    val items = getRecentProductUseCase()
+}

--- a/app/src/main/java/com/example/banchan/util/ext/TimeExt.kt
+++ b/app/src/main/java/com/example/banchan/util/ext/TimeExt.kt
@@ -1,0 +1,18 @@
+package com.example.banchan.util.ext
+
+fun Long.toTimeFormat(): String {
+    return when {
+        this < 60 -> {
+            "${this}초전"
+        }
+        this < 60 * 60 -> {
+            "${this / 60}분전"
+        }
+        this < 60 * 60 * 24 -> {
+            "${this / (60 * 60)}시간전"
+        }
+        else -> {
+            "${this / (60 * 60 * 24)}일전"
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -22,7 +22,7 @@
             android:id="@+id/tl_home"
             style="@style/home_tab_layout"
             android:layout_width="match_parent"
-            android:layout_height="42dp"
+            android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@id/ab_home" />
 
         <androidx.viewpager2.widget.ViewPager2

--- a/app/src/main/res/layout/fragment_recently_product.xml
+++ b/app/src/main/res/layout/fragment_recently_product.xml
@@ -32,6 +32,7 @@
         </androidx.appcompat.widget.Toolbar>
 
         <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_recently_product"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"

--- a/app/src/main/res/layout/item_recent.xml
+++ b/app/src/main/res/layout/item_recent.xml
@@ -9,18 +9,18 @@
 
         <variable
             name="item"
-            type="com.example.banchan.domain.model.ItemModel" />
+            type="com.example.banchan.domain.model.RecentlyProductModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="168dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
         <ImageView
             android:id="@+id/iv_banchan"
             imageUrl="@{item.image}"
-            android:layout_width="0dp"
-            android:layout_height="160dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
@@ -75,5 +75,15 @@
             app:layout_constraintStart_toEndOf="@id/tv_item_total"
             app:layout_constraintTop_toBottomOf="@id/tv_title"
             tools:text="1234원" />
+
+        <TextView
+            style="@style/tv_normal_12.GreyDefault"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@{item.time}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_item_total"
+            tools:text="4분전" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## Summary
최근 본 상품 목록 구현

## Main Changes
- 최근 본 상품 목록 구현

hash 키로 병렬적 api 요청 후 리스트에 반영하도록 구현했습니다.
click 관련해서는 꽤 수정해야할 사항이 있을거같아서 별도의 pr로 올리도록하겠습니다~ 

![image](https://user-images.githubusercontent.com/54823396/185306731-0c28c065-6726-4c44-948c-9be0184d2cff.png)

Closes #52 
