### PR TITLE
[FIX] 스크롤 초기화 버그 수정 #61 

### DIFF
--- a/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/home/maincook/MainCookViewModel.kt
@@ -10,7 +10,6 @@ import com.example.banchan.presentation.adapter.main.Type
 import com.example.banchan.util.ext.toNum
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -25,10 +24,9 @@ class MainCookViewModel @Inject constructor(
     private var filter = Filter.NORMAL
     private val _dishes =
         MutableStateFlow(listOf(MainItemListModel.MainHeader(), MainItemListModel.Loading))
-    val dishes = _dishes.asStateFlow()
 
     val mainItemListModel =
-        combine(dishes, getBasketItemUseCase()) { dishes, basketList ->
+        combine(_dishes, getBasketItemUseCase()) { dishes, basketList ->
             basketList.onSuccess {
                 return@combine checkIsCartAdded(dishes, it)
             }


### PR DESCRIPTION
## Summary
스크롤 초기화 버그 수정

## Main Changes
리스트 갱신될때마다 change type해서 스크롤 초기화되는 버그가 있었는데,
lazy job을 commit callback에서 start하게하여 버그 해결
<img src="https://user-images.githubusercontent.com/54823396/185386972-8f1826ec-f800-42bd-a9a8-f5f56902c530.gif" width="40%" />

Closes #61 

