### PR TITLE
[FEAT] 장바구니 API 데이터 수집 및 선택, 삭제 기능 구현

### DIFF
--- a/app/src/main/java/com/example/banchan/data/repository/BasketRepository.kt
+++ b/app/src/main/java/com/example/banchan/data/repository/BasketRepository.kt
@@ -7,4 +7,7 @@ interface BasketRepository {
     fun getBasketItems(): Flow<Result<List<BasketItem>>>
     suspend fun insertBasketItem(vararg basketItem: BasketItem): Result<Unit>
     suspend fun updateBasketItem(vararg basketItem: BasketItem): Result<Unit>
+    suspend fun updateAllBasketIsSelected(isSelected: Int): Result<Unit>
+    suspend fun deleteBasketItem(vararg basketItem: BasketItem): Result<Unit>
+    suspend fun deleteSelectedBasketItem(): Result<Unit>
 }

--- a/app/src/main/java/com/example/banchan/data/repository/BasketRepositoryImpl.kt
+++ b/app/src/main/java/com/example/banchan/data/repository/BasketRepositoryImpl.kt
@@ -16,4 +16,17 @@ class BasketRepositoryImpl @Inject constructor(
     override suspend fun updateBasketItem(vararg basketItem: BasketItem): Result<Unit> = runCatching {
         localDataSource.updateBasketItem(*basketItem)
     }
+
+    override suspend fun updateAllBasketIsSelected(isSelected: Int): Result<Unit> = runCatching {
+        localDataSource.updateAllBasketIsSelected(isSelected)
+    }
+
+    override suspend fun deleteBasketItem(vararg basketItem: BasketItem): Result<Unit> = runCatching {
+        localDataSource.deleteBasketItem(*basketItem)
+    }
+
+    override suspend fun deleteSelectedBasketItem(): Result<Unit> = runCatching {
+        localDataSource.deleteSelectedBasketItem()
+    }
+
 }

--- a/app/src/main/java/com/example/banchan/data/source/BasketDataSource.kt
+++ b/app/src/main/java/com/example/banchan/data/source/BasketDataSource.kt
@@ -7,4 +7,7 @@ interface BasketDataSource {
     fun getBasketItems(): Flow<Result<List<BasketItem>>>
     suspend fun insertBasketItem(vararg basketItem: BasketItem): Result<Unit>
     suspend fun updateBasketItem(vararg basketItem: BasketItem): Result<Unit>
+    suspend fun updateAllBasketIsSelected(isSelected: Int): Result<Unit>
+    suspend fun deleteBasketItem(vararg basketItem: BasketItem): Result<Unit>
+    suspend fun deleteSelectedBasketItem(): Result<Unit>
 }

--- a/app/src/main/java/com/example/banchan/data/source/local/basket/BasketDao.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/basket/BasketDao.kt
@@ -13,4 +13,14 @@ interface BasketDao {
 
     @Update
     fun updateBasketItem(vararg basketItem: BasketItem)
+
+    @Query("UPDATE basketitem SET isSelected = :isSelected")
+    fun updateAllBasketIsSelected(isSelected: Int)
+
+    @Delete
+    fun deleteBasketItem(vararg basketItem: BasketItem)
+
+    @Query("DELETE FROM basketitem WHERE isSelected = 1")
+    fun deleteSelectedBasketItem()
+
 }

--- a/app/src/main/java/com/example/banchan/data/source/local/basket/BasketLocalDataSource.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/basket/BasketLocalDataSource.kt
@@ -29,4 +29,23 @@ class BasketLocalDataSource @Inject constructor(
             basketDao.updateBasketItem(*basketItem)
         }
     }
+
+    override suspend fun updateAllBasketIsSelected(isSelected: Int) = runCatching {
+        withContext(ioDispatcher) {
+            basketDao.updateAllBasketIsSelected(isSelected)
+        }
+    }
+
+    override suspend fun deleteBasketItem(vararg basketItem: BasketItem) = runCatching {
+        withContext(ioDispatcher) {
+            basketDao.deleteBasketItem(*basketItem)
+        }
+    }
+
+    override suspend fun deleteSelectedBasketItem() = runCatching {
+        withContext(ioDispatcher) {
+            basketDao.deleteSelectedBasketItem()
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/banchan/domain/usecase/basket/DeleteBasketItemUseCase.kt
+++ b/app/src/main/java/com/example/banchan/domain/usecase/basket/DeleteBasketItemUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.banchan.domain.usecase.basket
+
+import com.example.banchan.data.repository.BasketRepository
+import com.example.banchan.data.source.local.basket.BasketItem
+import javax.inject.Inject
+
+class DeleteBasketItemUseCase @Inject constructor(
+    private val basketRepository: BasketRepository
+) {
+    suspend operator fun invoke(vararg basketItem: BasketItem): Result<Unit> =
+        basketRepository.deleteBasketItem(*basketItem)
+}

--- a/app/src/main/java/com/example/banchan/domain/usecase/basket/DeleteSelectedBasketItemUseCase.kt
+++ b/app/src/main/java/com/example/banchan/domain/usecase/basket/DeleteSelectedBasketItemUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.banchan.domain.usecase.basket
+
+import com.example.banchan.data.repository.BasketRepository
+import javax.inject.Inject
+
+class DeleteSelectedBasketItemUseCase @Inject constructor(
+    private val basketRepository: BasketRepository
+) {
+    suspend operator fun invoke(): Result<Unit> =
+        basketRepository.deleteSelectedBasketItem()
+}

--- a/app/src/main/java/com/example/banchan/domain/usecase/basket/UpdateAllBasketIsSelectedUseCase.kt
+++ b/app/src/main/java/com/example/banchan/domain/usecase/basket/UpdateAllBasketIsSelectedUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.banchan.domain.usecase.basket
+
+import com.example.banchan.data.repository.BasketRepository
+import javax.inject.Inject
+
+class UpdateAllBasketIsSelectedUseCase @Inject constructor(
+    private val basketRepository: BasketRepository
+) {
+    suspend operator fun invoke(isSelected: Int): Result<Unit> =
+        basketRepository.updateAllBasketIsSelected(isSelected)
+}

--- a/app/src/main/java/com/example/banchan/domain/usecase/basket/UpdateBasketItemUseCase.kt
+++ b/app/src/main/java/com/example/banchan/domain/usecase/basket/UpdateBasketItemUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.banchan.domain.usecase.basket
+
+import com.example.banchan.data.repository.BasketRepository
+import com.example.banchan.data.source.local.basket.BasketItem
+import javax.inject.Inject
+
+class UpdateBasketItemUseCase @Inject constructor(
+    private val basketRepository: BasketRepository
+) {
+    suspend operator fun invoke(vararg basketItem: BasketItem): Result<Unit> =
+        basketRepository.updateBasketItem(*basketItem)
+}

--- a/app/src/main/java/com/example/banchan/domain/usecase/recently/GetRecentlyItemUseCase.kt
+++ b/app/src/main/java/com/example/banchan/domain/usecase/recently/GetRecentlyItemUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.banchan.domain.usecase.recently
+
+import com.example.banchan.data.repository.RecentlyProductRepository
+import javax.inject.Inject
+
+class GetRecentlyItemUseCase @Inject constructor(
+    private val recentlyRepository: RecentlyProductRepository
+) {
+    operator fun invoke() =
+        recentlyRepository.getRecentlyProducts()
+}

--- a/app/src/main/java/com/example/banchan/presentation/adapter/basket/BasketItemViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/basket/BasketItemViewHolder.kt
@@ -11,8 +11,8 @@ class BasketItemViewHolder(private val binding: ItemBasketBinding) :
 
     fun initBind(
         basketModel: BasketModel,
-        onCheckBoxClick : ((BasketModel)->Unit),
-        onClickDeleteBtn: ((BasketModel)->Unit)
+        onCheckBoxClick: ((BasketModel) -> Unit),
+        onClickDeleteBtn: ((BasketModel) -> Unit)
     ) {
         binding.basketModel = basketModel
         binding.cbBasketItem.setOnClickListener { onCheckBoxClick(basketModel) }
@@ -21,8 +21,8 @@ class BasketItemViewHolder(private val binding: ItemBasketBinding) :
 
     fun refreshBind(
         basketModel: BasketModel,
-        onCheckBoxClick : ((BasketModel)->Unit),
-        onClickDeleteBtn: ((BasketModel)->Unit)
+        onCheckBoxClick: ((BasketModel) -> Unit),
+        onClickDeleteBtn: ((BasketModel) -> Unit)
     ) {
         binding.basketModel = basketModel
         binding.cbBasketItem.setOnClickListener { onCheckBoxClick(basketModel) }

--- a/app/src/main/java/com/example/banchan/presentation/adapter/basket/BasketItemViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/basket/BasketItemViewHolder.kt
@@ -9,8 +9,25 @@ import com.example.banchan.domain.model.BasketModel
 class BasketItemViewHolder(private val binding: ItemBasketBinding) :
     RecyclerView.ViewHolder(binding.root) {
 
-    fun binding(basketModel: BasketModel) {
+    fun initBind(
+        basketModel: BasketModel,
+        onCheckBoxClick : ((BasketModel)->Unit),
+        onClickDeleteBtn: ((BasketModel)->Unit)
+    ) {
         binding.basketModel = basketModel
+        binding.cbBasketItem.setOnClickListener { onCheckBoxClick(basketModel) }
+        binding.ivBasketItemDelete.setOnClickListener { onClickDeleteBtn(basketModel) }
+    }
+
+    fun refreshBind(
+        basketModel: BasketModel,
+        onCheckBoxClick : ((BasketModel)->Unit),
+        onClickDeleteBtn: ((BasketModel)->Unit)
+    ) {
+        binding.basketModel = basketModel
+        binding.cbBasketItem.setOnClickListener { onCheckBoxClick(basketModel) }
+        binding.ivBasketItemDelete.setOnClickListener { onClickDeleteBtn(basketModel) }
+        binding.executePendingBindings()
     }
 
     companion object {

--- a/app/src/main/java/com/example/banchan/presentation/adapter/basket/BasketListAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/basket/BasketListAdapter.kt
@@ -6,7 +6,8 @@ import androidx.recyclerview.widget.ListAdapter
 import com.example.banchan.domain.model.BasketModel
 
 class BasketListAdapter(
-
+    private val onCheckBoxClick: ((BasketModel) -> Unit),
+    private val onClickDeleteBtn: ((BasketModel) -> Unit)
 ) : ListAdapter<BasketModel, BasketItemViewHolder>(diffUtil) {
 
     companion object {
@@ -18,13 +19,34 @@ class BasketListAdapter(
             override fun areContentsTheSame(oldItem: BasketModel, newItem: BasketModel): Boolean {
                 return oldItem == newItem
             }
+
+            override fun getChangePayload(oldItem: BasketModel, newItem: BasketModel): Any? {
+                return (oldItem.count != newItem.count) || (oldItem.isChecked != newItem.isChecked)
+            }
         }
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BasketItemViewHolder
-        = BasketItemViewHolder.create(parent)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BasketItemViewHolder =
+        BasketItemViewHolder.create(parent)
 
     override fun onBindViewHolder(holder: BasketItemViewHolder, position: Int) {
-        holder.binding(getItem(position))
+        holder.initBind(getItem(position), onCheckBoxClick, onClickDeleteBtn)
+    }
+
+    override fun onBindViewHolder(
+        holder: BasketItemViewHolder,
+        position: Int,
+        payloads: MutableList<Any>
+    ) {
+        if (payloads.isEmpty()) {
+            super.onBindViewHolder(holder, position, payloads)
+        } else {
+            if (payloads[0] as Boolean) holder.refreshBind(
+                getItem(position),
+                onCheckBoxClick,
+                onClickDeleteBtn
+            )
+            else super.onBindViewHolder(holder, position, payloads)
+        }
     }
 }

--- a/app/src/main/java/com/example/banchan/presentation/adapter/basket/BasketTabAdapter.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/basket/BasketTabAdapter.kt
@@ -4,14 +4,15 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 
 class BasketTabAdapter(
-
+    private val onClickCheckBoxTab: ((Int)->Unit),
+    private val onClickSeletedDeleteBtn: (()->Unit)
 ) : RecyclerView.Adapter<BasketTabViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BasketTabViewHolder
         = BasketTabViewHolder.create(parent)
 
     override fun onBindViewHolder(holder: BasketTabViewHolder, position: Int) {
-
+        holder.bind(onClickCheckBoxTab, onClickSeletedDeleteBtn)
     }
 
     override fun getItemCount(): Int = 1

--- a/app/src/main/java/com/example/banchan/presentation/adapter/basket/BasketTabViewHolder.kt
+++ b/app/src/main/java/com/example/banchan/presentation/adapter/basket/BasketTabViewHolder.kt
@@ -4,11 +4,16 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.example.banchan.databinding.ItemBasketTabBinding
+import com.example.banchan.util.ext.toInt
 
-class BasketTabViewHolder(private val binding: ItemBasketTabBinding) :
-    RecyclerView.ViewHolder(binding.root) {
+class BasketTabViewHolder(
+    private val binding: ItemBasketTabBinding
+) : RecyclerView.ViewHolder(binding.root) {
 
-    fun bind() {
+    fun bind(onClickCheckBoxTab: ((Int) -> Unit), onClickSelectedDeleteBtn: (() -> Unit)) {
+        binding.ivBasketDoAllCheck.setOnClickListener { onClickCheckBoxTab(true.toInt()) }
+        binding.tvBasketUncheck.setOnClickListener { onClickCheckBoxTab(false.toInt()) }
+        binding.tvBasketCheckDelete.setOnClickListener { onClickSelectedDeleteBtn() }
     }
 
     companion object {

--- a/app/src/main/java/com/example/banchan/presentation/basket/BasketFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/basket/BasketFragment.kt
@@ -1,60 +1,97 @@
 package com.example.banchan.presentation.basket
 
-import android.os.Bundle
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.ConcatAdapter
 import com.example.banchan.R
+import com.example.banchan.databinding.FragmentBasketBinding
+import com.example.banchan.domain.model.BasketModel
+import com.example.banchan.presentation.adapter.basket.BasketListAdapter
+import com.example.banchan.presentation.adapter.basket.BasketOrderAdapter
+import com.example.banchan.presentation.adapter.basket.BasketRecentlyTabAdapter
+import com.example.banchan.presentation.adapter.basket.BasketTabAdapter
+import com.example.banchan.presentation.base.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
+@AndroidEntryPoint
+class BasketFragment : BaseFragment<FragmentBasketBinding>(R.layout.fragment_basket) {
 
-/**
- * A simple [Fragment] subclass.
- * Use the [BasketFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
-class BasketFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
+    private val basketViewModel: BasketViewModel by viewModels()
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
+    private val onCheckBoxClick: ((BasketModel) -> Unit) = { basketModel ->
+        basketViewModel.updateBasketItem(basketModel)
+    }
+
+    private val onClickCheckBoxTab: ((Int) -> Unit) = { isSelected ->
+        basketViewModel.updateAllBasketIsSelected(isSelected)
+    }
+
+    private val onClickSeletedDeleteBtn: (() -> Unit) = {
+        basketViewModel.deleteSelectedBasketItems()
+    }
+
+    private val onClickDeleteBtn: ((BasketModel) -> Unit) = { basketModel ->
+        basketViewModel.deleteBasketItem(basketModel)
+    }
+
+    private val basketListTabAdapter by lazy {
+        BasketTabAdapter(
+            onClickCheckBoxTab,
+            onClickSeletedDeleteBtn
+        )
+    }
+    private val basketListAdapter by lazy { BasketListAdapter(onCheckBoxClick, onClickDeleteBtn) }
+    private val basketOrderAdapter by lazy { BasketOrderAdapter() }
+    private val basketRecentlyTabAdapter by lazy { BasketRecentlyTabAdapter() }
+
+    override fun initViews() {
+        initRecyclerView()
+    }
+
+    override fun observe() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    basketViewModel.basketItemFlow.collectLatest {
+                        basketListAdapter.submitList(it)
+                        basketViewModel.setIsBasketLoading(false)
+                    }
+                }
+
+                launch {
+                    basketViewModel.recentlyProductFlow.collectLatest {
+                        basketRecentlyTabAdapter.setRecentlyViewedList(it)
+                        basketViewModel.setIsRecentlyLoading(false)
+                    }
+                }
+
+                launch {
+                    basketViewModel.isLoading.collectLatest { isLoading ->
+                        if (isLoading) {
+                            binding.pbBasketLoading.visibility = View.VISIBLE
+                            binding.rvBasketList.visibility = View.INVISIBLE
+                        } else {
+                            binding.pbBasketLoading.visibility = View.INVISIBLE
+                            binding.rvBasketList.visibility = View.VISIBLE
+                        }
+                    }
+                }
+            }
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_basket, container, false)
+    private fun initRecyclerView() {
+        binding.rvBasketList.adapter = ConcatAdapter(
+            basketListTabAdapter,
+            basketListAdapter,
+            basketOrderAdapter,
+            basketRecentlyTabAdapter
+        )
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment BasketFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            BasketFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
-            }
-    }
 }

--- a/app/src/main/java/com/example/banchan/presentation/basket/BasketFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/basket/BasketFragment.kt
@@ -31,7 +31,7 @@ class BasketFragment : BaseFragment<FragmentBasketBinding>(R.layout.fragment_bas
         basketViewModel.updateAllBasketIsSelected(isSelected)
     }
 
-    private val onClickSeletedDeleteBtn: (() -> Unit) = {
+    private val onClickSelectedDeleteBtn: (() -> Unit) = {
         basketViewModel.deleteSelectedBasketItems()
     }
 
@@ -42,7 +42,7 @@ class BasketFragment : BaseFragment<FragmentBasketBinding>(R.layout.fragment_bas
     private val basketListTabAdapter by lazy {
         BasketTabAdapter(
             onClickCheckBoxTab,
-            onClickSeletedDeleteBtn
+            onClickSelectedDeleteBtn
         )
     }
     private val basketListAdapter by lazy { BasketListAdapter(onCheckBoxClick, onClickDeleteBtn) }

--- a/app/src/main/java/com/example/banchan/presentation/basket/BasketViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/basket/BasketViewModel.kt
@@ -1,0 +1,91 @@
+package com.example.banchan.presentation.basket
+
+import androidx.lifecycle.ViewModel
+import com.example.banchan.data.response.detail.DetailResponse
+import com.example.banchan.data.source.local.basket.BasketItem
+import com.example.banchan.data.source.local.recent.RecentlyProduct
+import com.example.banchan.domain.model.BasketModel
+import com.example.banchan.domain.model.RecentlyProductModel
+import com.example.banchan.domain.usecase.basket.GetBasketItemUseCase
+import com.example.banchan.domain.usecase.detail.GetProductDetailUseCase
+import com.example.banchan.domain.usecase.recently.GetRecentlyItemUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@HiltViewModel
+class BasketViewModel @Inject constructor(
+    private val getBasketItemUseCase: GetBasketItemUseCase,
+    private val getRecentlyItemUseCase: GetRecentlyItemUseCase,
+    private val getProductDetailUseCase: GetProductDetailUseCase
+) : ViewModel() {
+
+    private val basketDbFlow: Flow<List<BasketItem>> =
+        getBasketItemUseCase().map { result ->
+            result.onSuccess { return@map it }
+            listOf()
+        }
+
+    private val recentlyProductDbFlow: Flow<List<RecentlyProduct>> =
+        getRecentlyItemUseCase().map { result ->
+            result.onSuccess { return@map it }
+            listOf()
+        }
+
+    private val detailApiMap: MutableMap<String,DetailResponse> = mutableMapOf()
+
+    private val _isBasketLoading = MutableStateFlow<Boolean>(true)
+    private val _isRecentlyLoading = MutableStateFlow<Boolean>(true)
+
+    fun setIsBasketLoading(isLoading: Boolean){
+        _isBasketLoading.value = isLoading
+    }
+
+    fun setIsRecentlyLoading(isLoading: Boolean){
+        _isRecentlyLoading.value = isLoading
+    }
+
+    val isLoading =
+        combine(_isBasketLoading, _isRecentlyLoading) { isBasketLoading, isRecentlyLoading ->
+            isBasketLoading || isRecentlyLoading
+        }
+
+    val basketItemFlow: Flow<List<BasketModel>> =
+        basketDbFlow
+            .map { basketList ->
+                return@map basketList.mapNotNull { basketItem ->
+                    checkDetailApiMap(basketItem.hash)
+                    return@mapNotNull detailApiMap[basketItem.hash]?.toBasketModel(
+                        name = basketItem.name,
+                        count = basketItem.count,
+                        isSelected = basketItem.isSelected
+                    )
+                }
+            }
+
+
+    val recentlyProductFlow: Flow<List<RecentlyProductModel>> =
+        recentlyProductDbFlow
+            .map { basketList ->
+                return@map basketList.mapNotNull { recentlyItem ->
+                    checkDetailApiMap(recentlyItem.hash)
+                    return@mapNotNull detailApiMap[recentlyItem.hash]?.toRecentlyProductModel(
+                        name = recentlyItem.name,
+                        time = "5분 전"
+                    )
+                }
+            }
+
+    private suspend fun checkDetailApiMap(hash: String) {
+        if (!(detailApiMap.containsKey(hash))) {
+            getProductDetailUseCase.invoke(hash)
+                .onSuccess {
+                    detailApiMap[hash] = it
+                }
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/banchan/util/ext/BooleanExt.kt
+++ b/app/src/main/java/com/example/banchan/util/ext/BooleanExt.kt
@@ -1,0 +1,3 @@
+package com.example.banchan.util.ext
+
+fun Boolean.toInt() = if(this) 1 else 0

--- a/app/src/main/res/layout/fragment_basket.xml
+++ b/app/src/main/res/layout/fragment_basket.xml
@@ -36,9 +36,21 @@
             android:id="@+id/rv_basket_list"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:visibility="visible"
             app:layout_constraintTop_toBottomOf="@id/tb_basket"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+
+        <ProgressBar
+            android:id="@+id/pb_basket_loading"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/rv_basket_list"
+            app:layout_constraintTop_toBottomOf="@+id/tb_basket" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/item_basket.xml
+++ b/app/src/main/res/layout/item_basket.xml
@@ -61,6 +61,7 @@
             tools:text="6,000원" />
 
         <com.example.banchan.presentation.custom.AmountCounter
+            android:id="@+id/basket_amount_counter"
             android:layout_width="88dp"
             android:layout_height="24dp"
             android:layout_marginTop="8dp"
@@ -69,6 +70,7 @@
             app:layout_constraintTop_toBottomOf="@id/tv_basket_item_price" />
 
         <ImageView
+            android:id="@+id/iv_basket_item_delete"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="16dp"

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,7 +6,7 @@
         <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">#FFFFFF</item>
+        <item name="colorSecondary">@color/primary_main</item>
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->


### PR DESCRIPTION
## Summary
- 장바구니에 담긴 상품의 해쉬 값을 이용하여 최신 상품 정보를 API로 수집하도록 구현하였습니다.
  (현재 수집한 API 데이터를 Map으로 저장하고 있는데 주말 동안에 flow로 변경할 예정입니다.)
- 장바구니 선택, 삭제 기능을 구현하였습니다.
- 전체 선택, 선택 삭제는 쿼리문을 추가하였습니다.
- 현재 UI 상태가 DB flow에 따라 업데이트 되도록 하였는데 더 빠른 반응속도 향상을 위해 개선을 할 예정입니다.

## Main Changes
- [x] 장바구니, 최근 본 상품 DB에서 hash 값 읽고 API로 상품정보 연동하기
- [x] 개별 체크, 전체 체크시 DB와 연동되도록 구현
- [x] 개별 삭제, 선택 삭제시 DB와 연동되도록 구현

Closes #59

![Aug-19-2022 00-32-39](https://user-images.githubusercontent.com/29484377/185435351-d8ef9435-3710-43d7-962c-a035f4c0db90.gif)

