### PR TITLE
[FEAT] 배송 완료 notification 구현 #78

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,6 +3,7 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="../../../../layout/custom_preview.xml" value="0.11018518518518519" />
         <entry key="app/src/main/res/drawable/background_line.xml" value="0.1135" />
         <entry key="app/src/main/res/drawable/bg_basket_checkbox.xml" value="0.223" />
         <entry key="app/src/main/res/drawable/bg_main_title_tv.xml" value="0.1" />
@@ -32,10 +33,12 @@
         <entry key="app/src/main/res/layout/fragment_side.xml" value="0.16302083333333334" />
         <entry key="app/src/main/res/layout/fragment_soup.xml" value="0.33" />
         <entry key="app/src/main/res/layout/item_banchan.xml" value="0.5686782836914064" />
-        <entry key="app/src/main/res/layout/item_basket.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/item_basket.xml" value="0.24010416666666667" />
         <entry key="app/src/main/res/layout/item_basket_list.xml" value="0.75" />
-        <entry key="app/src/main/res/layout/item_basket_recently_product.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/item_basket_order.xml" value="0.10099637681159421" />
+        <entry key="app/src/main/res/layout/item_basket_recently_product.xml" value="0.9" />
         <entry key="app/src/main/res/layout/item_basket_recently_tab.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/item_basket_tab.xml" value="0.1828774062816616" />
         <entry key="app/src/main/res/layout/item_best_list.xml" value="0.33" />
         <entry key="app/src/main/res/layout/item_home_empty.xml" value="0.375" />
         <entry key="app/src/main/res/layout/item_home_error.xml" value="0.375" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
     package="com.example.banchan">
 
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+
     <application
         android:name=".BanChanApp"
         android:allowBackup="true"
@@ -16,15 +19,22 @@
         android:theme="@style/Theme.Banchan"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
+        <receiver
+            android:name=".AlarmReceiver"
+            android:enabled="true"
+            android:exported="true" />
+
         <activity
             android:name=".presentation.main.MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
         <service android:name=".OrderService" />
     </application>
 

--- a/app/src/main/java/com/example/banchan/AlarmReceiver.kt
+++ b/app/src/main/java/com/example/banchan/AlarmReceiver.kt
@@ -1,0 +1,66 @@
+package com.example.banchan
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.example.banchan.presentation.main.MainActivity
+import com.example.banchan.util.DEFAULT_DELIVERY_TIME
+
+class AlarmReceiver : BroadcastReceiver() {
+    lateinit var notificationManager: NotificationManager
+
+    override fun onReceive(context: Context, intent: Intent) {
+        notificationManager = context.getSystemService(
+            Context.NOTIFICATION_SERVICE
+        ) as NotificationManager
+
+        createNotificationChannel()
+        createNotification(context)
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationChannel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_HIGH
+            )
+            notificationChannel.enableVibration(true)
+            notificationManager.createNotificationChannel(notificationChannel)
+        }
+    }
+
+    private fun createNotification(context: Context) {
+        val contentIntent = Intent(context, MainActivity::class.java)
+        val contentPendingIntent = PendingIntent.getActivity(
+            context,
+            NOTIFICATION_ID,
+            contentIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_cart)
+            .setContentTitle(context.getString(R.string.notification_title))
+            .setContentText(context.getString(R.string.notification_content))
+            .setContentIntent(contentPendingIntent)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .setDefaults(NotificationCompat.DEFAULT_ALL)
+
+        notificationManager.notify(NOTIFICATION_ID, builder.build())
+    }
+
+    companion object {
+        const val NOTIFICATION_ID = 0
+        const val CHANNEL_ID = "delivery channel"
+        const val CHANNEL_NAME = "delivery channel"
+
+        const val ALARM_TIMER = DEFAULT_DELIVERY_TIME * 60 * 1000
+    }
+}

--- a/app/src/main/java/com/example/banchan/OrderService.kt
+++ b/app/src/main/java/com/example/banchan/OrderService.kt
@@ -20,7 +20,7 @@ class OrderService : LifecycleService() {
         lifecycleScope.launch {
             while (isActive) {
                 updateHistoryUseCase()
-                delay(1000 * 60)
+                delay(1000 * 30)
             }
         }
     }

--- a/app/src/main/java/com/example/banchan/data/source/local/history/History.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/history/History.kt
@@ -2,6 +2,7 @@ package com.example.banchan.data.source.local.history
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.example.banchan.util.DEFAULT_DELIVERY_TIME
 import java.util.*
 
 @Entity
@@ -9,5 +10,5 @@ data class History(
     @PrimaryKey(autoGenerate = true)
     val id: Long,
     val date: Date = Date(),
-    val remainTime: Int = 5
+    val remainTime: Int = DEFAULT_DELIVERY_TIME
 )

--- a/app/src/main/java/com/example/banchan/presentation/basket/BasketFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/basket/BasketFragment.kt
@@ -1,11 +1,17 @@
 package com.example.banchan.presentation.basket
 
+import android.app.AlarmManager
+import android.app.Application
+import android.app.PendingIntent
+import android.content.Intent
+import android.os.SystemClock
 import android.view.View
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.ConcatAdapter
+import com.example.banchan.AlarmReceiver
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentBasketBinding
 import com.example.banchan.domain.model.BasketModel
@@ -131,4 +137,20 @@ class BasketFragment : BaseFragment<FragmentBasketBinding>(R.layout.fragment_bas
         )
     }
 
+    private fun makeAlarm() {
+        requireContext().run {
+            val alarmManager = getSystemService(Application.ALARM_SERVICE) as AlarmManager
+            val triggerTime = (SystemClock.elapsedRealtime() + AlarmReceiver.ALARM_TIMER)
+            val pendingIntent = PendingIntent.getBroadcast(
+                this, triggerTime.toInt(), Intent(this, AlarmReceiver::class.java),
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+
+            alarmManager.setExact(
+                AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                triggerTime,
+                pendingIntent
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
@@ -39,7 +39,7 @@ class MainActivity : AppCompatActivity() {
                     if (targetFragment == null) {
                         // 추후 다른 Fragment 생성 후 수정 예정
                         val fragment = when (it) {
-                            FragmentType.Home -> HomeFragment()
+                            FragmentType.Home -> OrderSuccessFragment()
                             FragmentType.Basket -> BasketFragment()
                             FragmentType.OrderDetail -> HomeFragment()
                             FragmentType.ProductDetail -> ProductDetailFragment()

--- a/app/src/main/java/com/example/banchan/presentation/ordersuccess/OrderSuccessFragment.kt
+++ b/app/src/main/java/com/example/banchan/presentation/ordersuccess/OrderSuccessFragment.kt
@@ -1,10 +1,16 @@
 package com.example.banchan.presentation.ordersuccess
 
+import android.app.AlarmManager
+import android.app.Application
+import android.app.PendingIntent
+import android.content.Intent
+import android.os.SystemClock
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.ConcatAdapter
+import com.example.banchan.AlarmReceiver
 import com.example.banchan.R
 import com.example.banchan.databinding.FragmentOrderSuccessBinding
 import com.example.banchan.presentation.adapter.common.CommonOrderFooterAdapter

--- a/app/src/main/java/com/example/banchan/presentation/ordersuccess/OrderSuccessViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/ordersuccess/OrderSuccessViewModel.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class OrderSuccessViewModel @Inject constructor(
-    private val getHistoryByIdUseCase: GetHistoryByIdUseCase,
+    getHistoryByIdUseCase: GetHistoryByIdUseCase,
     private val updateHistoryUseCase: UpdateHistoryUseCase
 ) : ViewModel() {
     val history = getHistoryByIdUseCase(1)

--- a/app/src/main/java/com/example/banchan/util/Constant.kt
+++ b/app/src/main/java/com/example/banchan/util/Constant.kt
@@ -1,4 +1,4 @@
 package com.example.banchan.util
 
-const val DEFAULT_DELIVERY_TIME = 20
+const val DEFAULT_DELIVERY_TIME = 1
 const val DEFAULT_DELIVERY_FEE = 2500

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,4 +65,6 @@
     <string name="minute_format">%d분</string>
     <string name="amount_format">%d원</string>
 
+    <string name="notification_title">[BanChan] 배달 완료</string>
+    <string name="notification_content">배송이 완료되었습니다.</string>
 </resources>


### PR DESCRIPTION
## Summary
배송 완료 notification 구현

## Main Changes
- 배송 완료 notification 구현

현재 테스트용으로 배달시간 1분으로 수정해두었습니다. 
추후에 20분으로 바꾸면 될거같습니다~
<img src="https://user-images.githubusercontent.com/54823396/185750458-9c1b4ad3-b379-4cd0-a468-c008665fc978.gif" width="50%"/>

Closes #78 
