### PR TITLE
[FEAT] 네트워크 체크 #96

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.banchan"
-        minSdk 23
+        minSdk 24
         targetSdk 32
         versionCode 1
         versionName "1.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     package="com.example.banchan">
 
     <uses-permission android:name="android.permission.INTERNET" />
-
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <application

--- a/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/banchan/presentation/main/MainActivity.kt
@@ -12,20 +12,44 @@ import com.example.banchan.presentation.home.HomeFragment
 import com.example.banchan.presentation.orderlist.OrderListFragment
 import com.example.banchan.presentation.productdetail.ProductDetailFragment
 import com.example.banchan.presentation.recentlyproduct.RecentlyProductFragment
+import com.example.banchan.util.NetworkConnectManager
+import com.google.android.material.snackbar.Snackbar
 import com.example.banchan.presentation.ordersuccess.OrderSuccessFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     lateinit var binding: ActivityMainBinding
-
+    @Inject
+    lateinit var networkConnectManager: NetworkConnectManager
+    
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         installSplashScreen()
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         observe()
+
+        networkConnectManager.init(
+            onConnectAction = {
+                Snackbar.make(
+                    binding.root,
+                    getString(R.string.network_enable),
+                    Snackbar.LENGTH_LONG
+                ).show()
+            },
+            onDisconnectAction = {
+                Snackbar.make(
+                    binding.root,
+                    getString(R.string.network_disable),
+                    Snackbar.LENGTH_INDEFINITE
+                ).show()
+            })
+        lifecycle.addObserver(networkConnectManager)
 
         if (savedInstanceState == null) {
             supportFragmentManager.commit {

--- a/app/src/main/java/com/example/banchan/util/NetworkConnectManager.kt
+++ b/app/src/main/java/com/example/banchan/util/NetworkConnectManager.kt
@@ -1,0 +1,63 @@
+package com.example.banchan.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NetworkConnectManager @Inject constructor(
+    @ApplicationContext context: Context
+) : DefaultLifecycleObserver {
+    private var isLastStateDisconnect = false
+    private val connectivityManager: ConnectivityManager =
+        context.getSystemService(ConnectivityManager::class.java)
+    private val networkInfo =
+        connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+
+    private var onConnect: () -> Unit = {}
+    private var onDisconnect: () -> Unit = {}
+
+    private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            if (isLastStateDisconnect) {
+                onConnect()
+                isLastStateDisconnect = false
+            }
+        }
+
+        override fun onLost(network: Network) {
+            isLastStateDisconnect = true
+            onDisconnect()
+        }
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+        super.onResume(owner)
+
+        connectivityManager.registerDefaultNetworkCallback(networkCallback)
+    }
+
+    override fun onPause(owner: LifecycleOwner) {
+        super.onPause(owner)
+
+        connectivityManager.unregisterNetworkCallback(networkCallback)
+    }
+
+    fun init(onConnectAction: () -> Unit, onDisconnectAction: () -> Unit) {
+        onConnect = onConnectAction
+        onDisconnect = onDisconnectAction
+
+        if ((networkInfo?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true ||
+                    networkInfo?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true).not()
+        ) {
+            isLastStateDisconnect = true
+            onDisconnect()
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,4 +71,7 @@
 
     <string name="notification_title">[BanChan] 배달 완료</string>
     <string name="notification_content">배송이 완료되었습니다.</string>
+
+    <string name="network_disable">네트워크 연결을 확인해주세요</string>
+    <string name="network_enable">네트워크가 연결되었습니다</string>
 </resources>


### PR DESCRIPTION
## Summary
네트워크 체크

## Main Changes
- 네트워크 연결 끊김, 연결 observe(on resume ~ on pause) 해서 스낵바 보여주도록 구현
- 네트워크 매니저 싱글톤으로 관리

https://user-images.githubusercontent.com/54823396/186418181-941a86b9-7b62-4ec4-9753-14832328cba2.mp4

Closes #96 