### PR TITLE
[REFACTOR] 장바구니 아이템 API 수집 속도 개선

### DIFF
--- a/app/src/main/java/com/example/banchan/data/response/detail/DetailResponse.kt
+++ b/app/src/main/java/com/example/banchan/data/response/detail/DetailResponse.kt
@@ -33,7 +33,7 @@ data class DetailResponse(
         )
     }
 
-    fun toBasketModel(name: String, count: Int, isSelected: Boolean): BasketModel {
+    fun toBasketModel(name: String, count: Int, isSelected: Boolean, time: Long): BasketModel {
         return BasketModel(
             name = name,
             count = count,
@@ -41,6 +41,7 @@ data class DetailResponse(
             detailHash = hash,
             price = if (data.prices.size == 1) data.prices[0].toNum() else data.prices[1].toNum(),
             image = data.thumbImages[0],
+            time = time
         )
     }
 

--- a/app/src/main/java/com/example/banchan/data/source/local/basket/BasketItem.kt
+++ b/app/src/main/java/com/example/banchan/data/source/local/basket/BasketItem.kt
@@ -2,6 +2,7 @@ package com.example.banchan.data.source.local.basket
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.*
 
 @Entity
 data class BasketItem(
@@ -9,5 +10,6 @@ data class BasketItem(
     val hash: String,
     val count: Int,
     val name: String,
-    val isSelected: Boolean
+    val isSelected: Boolean,
+    val time: Long = Date().time
 )

--- a/app/src/main/java/com/example/banchan/domain/model/BasketModel.kt
+++ b/app/src/main/java/com/example/banchan/domain/model/BasketModel.kt
@@ -5,10 +5,11 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class BasketModel(
-    val detailHash : String,
-    val count : Int,
-    val isChecked : Boolean = true,
-    val name : String,
-    val price : Int,
-    val image : String
-): Parcelable
+    val detailHash: String,
+    val count: Int,
+    val isChecked: Boolean = true,
+    val name: String,
+    val price: Int,
+    val image: String,
+    val time: Long,
+) : Parcelable

--- a/app/src/main/java/com/example/banchan/presentation/dialog/AmountDialogViewModel.kt
+++ b/app/src/main/java/com/example/banchan/presentation/dialog/AmountDialogViewModel.kt
@@ -40,6 +40,7 @@ class AmountDialogViewModel @Inject constructor(
                         name = basketModel.name,
                         count = amount.value,
                         isSelected = basketModel.isChecked,
+                        time = basketModel.time
                     )
                 )
             }


### PR DESCRIPTION
## 목적
- 기존 순차적으로 API를 수집하고 있던 로직을 flatMapMerge를 적용하여 병렬적으로 API를 수집하여 속도를 개선합니다.
- 병렬적으로 수집시 순서가 꼬일 수도 있으므로 time 필드를 추가하여 장바구니에 추가된 순서대로 보일 수 있도록 합니다.

## 작업 상세 내용
- [x] 장바구니 수집 로직 flatMapMerge 적용
- [x] Basket Table에 Time Column 추가
- [x] BasketItem Time Field 추가

Closes #162 
